### PR TITLE
:bookmark: Release 2.32.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
 Release History
 ===============
 
-2.32.1 (2023-09-??)
+2.32.1 (2023-09-12)
+-------------------
 
 **Bugfixes**
 - Fix QUIC cache when using requests.request without persistent Session
+
+**Dependencies**
+- urllib3.future minimal version supported raised to 2.0.932 (ship with critical fixes)
 
 2.32.0 (2023-08-29)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if sys.argv[-1] == "publish":
 requires = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.0.931,<3",
+    "urllib3.future>=2.0.932,<3",
     "certifi>=2017.4.17",
 ]
 test_requirements = [


### PR DESCRIPTION
2.32.1 (2023-09-12)
-------------------

**Bugfixes**
- Fix QUIC cache when using requests.request without persistent Session

**Dependencies**
- urllib3.future minimal version supported raised to 2.0.932 (ship with critical fixes)
