### PR TITLE
:bug: Fix unattended crash when server specify a non-compliant Location header on redirection

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -55,6 +55,9 @@ Release History
 - An invalid content-type definition would cause the charset being evaluated to `True`, thus making the program crash.
 - Given `proxies` could be mutated when environment proxies were evaluated and injected. This package should not modify your inputs.
   For context see https://github.com/psf/requests/issues/6118
+- A server could specify a `Location` header that does not comply to HTTP specifications and could lead to an unexpected exception.
+  We try to fall back to Unicode decoding if the typical and expected Latin-1 would fail. If that fails too, a proper exception is raised.
+  For context see https://github.com/psf/requests/issues/6026
 
 2.32.1 (2023-09-12)
 -------------------

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -52,6 +52,21 @@ class TestTestServer:
             assert r.text == "roflol"
             assert r.headers["Content-Length"] == "6"
 
+    def test_invalid_location_response(self):
+        server = Server.text_response_server(
+            "HTTP/1.1 302 PERMANENT-REDIRECTION\r\n"
+            "Location: http://localhost:1/search/?q=ïðåçèäåíòû+ÑØÀ\r\n\r\n"
+        )
+
+        with server as (host, port):
+            with pytest.raises(niquests.exceptions.ConnectionError) as exc:
+                niquests.get(f"http://{host}:{port}")
+            msg = exc.value.args[0].args[0]
+            assert (
+                "/search/?q=%C3%AF%C3%B0%C3%A5%C3%A7%C3%A8%C3%A4%C3%A5%C3%AD%C3%B2%C3%BB+%C3%91%C3%98%C3%80"
+                in msg
+            )
+
     def test_basic_response(self):
         """the basic response server returns an empty http response"""
         with Server.basic_response_server() as (host, port):


### PR DESCRIPTION
Linked to https://github.com/psf/requests/issues/6026

Not really a bug per se, but
I cannot accept that a server forces our hand by raising an unexpected exception. (Namely UnicodeDecodeError)