### PR TITLE
:wrench: Remove the warning about opening a file in text mode

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,10 @@ Release History
   a `PreparedRequest` instance. Finally, the `pre_send` will be triggered just after picking a (live) connection
   for your request. The two events receive a `PreparedRequest` instance.
 
+**Removed**
+- Warning emitted when passing a file opened in text-mode instead of binary. urllib3.future can overrule
+  the content-length if it detects an error. You should not encounter broken request being sent.
+
 3.0.0b1 (2023-09-22)
 -------------------
 

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -17,7 +17,6 @@ import struct
 import sys
 import tempfile
 import typing
-import warnings
 from collections import OrderedDict
 from http.cookiejar import CookieJar
 from urllib.parse import quote, unquote, urlparse, urlunparse
@@ -43,12 +42,7 @@ from ._internal_utils import (  # noqa: F401
     to_native_string,
 )
 from .cookies import cookiejar_from_dict
-from .exceptions import (
-    FileModeWarning,
-    InvalidHeader,
-    InvalidURL,
-    UnrewindableBodyError,
-)
+from .exceptions import InvalidHeader, InvalidURL, UnrewindableBodyError
 from .structures import CaseInsensitiveDict
 
 if typing.TYPE_CHECKING:
@@ -136,21 +130,6 @@ def super_len(o: typing.Any) -> int:
             pass
         else:
             total_length = os.fstat(fileno).st_size
-
-            # Having used fstat to determine the file length, we need to
-            # confirm that this file was opened up in binary mode.
-            if "b" not in o.mode:
-                warnings.warn(
-                    (
-                        "Requests has determined the content-length for this "
-                        "request using the binary size of the file: however, the "
-                        "file has been opened in text mode (i.e. without the 'b' "
-                        "flag in the mode). This may lead to an incorrect "
-                        "content-length. In Requests 3.0, support will be removed "
-                        "for files in text mode."
-                    ),
-                    FileModeWarning,
-                )
 
     if hasattr(o, "tell"):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,18 +93,17 @@ class TestSuperLen:
         assert super_len("Test") == 4
 
     @pytest.mark.parametrize(
-        "mode, warnings_num",
+        "mode",
         (
-            ("r", 1),
-            ("rb", 0),
+            "r",
+            "rb",
         ),
     )
-    def test_file(self, tmpdir, mode, warnings_num, recwarn):
+    def test_file(self, tmpdir, mode, recwarn):
         file_obj = tmpdir.join("test.txt")
         file_obj.write("Test")
         with file_obj.open(mode) as fd:
             assert super_len(fd) == 4
-        assert len(recwarn) == warnings_num
 
     def test_tarfile_member(self, tmpdir):
         file_obj = tmpdir.join("test.txt")


### PR DESCRIPTION
urllib3.future can overrule this (in case) to avoid a broken request being emitted.
but the reported size is correct.