### PR TITLE
:bookmark: Release 3.0.2

### DIFF
--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
-__build__: int = 0x030000
+__build__: int = 0x030002
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"


### PR DESCRIPTION
3.0.2 (2023-10-01)
------------------

**Changed**
- niquests.help show more information about direct dependencies.
- urllib3.future minimal version was raised to 2.0.936 due to an important fix on the QUIC layer.
- wassima minimal version was raised to 1.0.1 in order to support certifi as a fallback in rare cases.
