### PR TITLE
:bookmark: Release 3.1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+3.1.1 (2023-10-11)
+------------------
+
+**Fixed**
+- Fixed `Transfer-Encoding` wrongfully added to headers when body is actually of length 0. Due to ambiguous return of `super_len` in niquests internals.
+- Fixed accepting three-valued tuple for Timeout (connect, read, total) in addition of known (connect, read) tuple.
+
 3.1.0 (2023-10-10)
 ------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,16 +78,6 @@ Authentication
 .. autoclass:: niquests.auth.HTTPProxyAuth
 .. autoclass:: niquests.auth.HTTPDigestAuth
 
-
-
-Encodings
----------
-
-.. autofunction:: niquests.utils.get_encodings_from_content
-.. autofunction:: niquests.utils.get_encoding_from_headers
-.. autofunction:: niquests.utils.get_unicode_from_response
-
-
 .. _api-cookies:
 
 Cookies

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
-__build__: int = 0x030100
+__build__: int = 0x030101
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -542,15 +542,21 @@ class HTTPAdapter(BaseAdapter):
             proxies=proxies,
         )
 
-        chunked = not (request.body is None or "Content-Length" in request.headers)
+        chunked = not (
+            bool(request.body) is False or "Content-Length" in request.headers
+        )
 
         if isinstance(timeout, tuple):
             try:
-                connect, read = timeout
-                timeout = TimeoutSauce(connect=connect, read=read)
+                if len(timeout) == 3:
+                    connect, read, total = timeout  # type: ignore[assignment]
+                else:
+                    connect, read = timeout  # type: ignore[assignment]
+                    total = None
+                timeout = TimeoutSauce(connect=connect, read=read, total=total)
             except ValueError:
                 raise ValueError(
-                    f"Invalid timeout {timeout}. Pass a (connect, read) timeout tuple, "
+                    f"Invalid timeout {timeout}. Pass a (connect, read) or (connect, read, total) timeout tuple, "
                     f"or a single float to set both timeouts to the same value."
                 )
         elif isinstance(timeout, TimeoutSauce):

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -30,6 +30,7 @@ from urllib3.util.url import parse_url
 from ..exceptions import RequestException, SSLError
 from ..models import PreparedRequest
 from ._picotls import (
+    ALERT,
     CHANGE_CIPHER,
     HANDSHAKE,
     derive_secret,
@@ -180,6 +181,7 @@ def _ask_nicely_for_issuer(
     for der in der_certificates:
         certificates.append(load_der_x509_certificate(der))
 
+    send_tls(sock, ALERT, b"\x01\x00")
     sock.close()
 
     if len(certificates) <= 1:

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -470,7 +470,7 @@ class PreparedRequest:
 
             if length:
                 self.headers["Content-Length"] = str(length)
-            else:
+            elif body:
                 self.headers["Transfer-Encoding"] = "chunked"
         else:
             # Multi-part file uploads.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2424,7 +2424,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         "timeout, error_text",
         (
-            ((3, 4, 5), "(connect, read)"),
+            ((3, 4, 5, 5), "(connect, read, total)"),
             ("foo", "must be an int, float or None"),
         ),
     )


### PR DESCRIPTION
3.1.1 (2023-10-11)
------------------

**Fixed**
- Fixed `Transfer-Encoding` wrongfully added to headers when body is actually of length 0. Due to the ambiguous return of `super_len` in niquests internals.
- Fixed accepting three-valued tuple for Timeout (connect, read, total) in addition to known (connect, read) tuple.
