### PR TITLE
:bookmark: Release 3.1.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.1.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.1.902', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,17 @@
 Release History
 ===============
 
+3.1.4 (2023-10-23)
+------------------
+
+**Fixed**
+- Static type checker not accepting **iterable\[str\]** for **data**. A fix in urllib3.future allows it since v2.1.902.
+- Unattended override of manually provided **Authorization** if `.netrc` existed with an eligible entry.
+  Taken from closed PR https://github.com/psf/requests/pull/6555 and initially raised in https://github.com/psf/requests/issues/3929
+
+**Added**
+- **oheaders** property in `Request`, and `PreparedRequest` in addition to `Response`.
+
 3.1.3 (2023-10-19)
 ------------------
 

--- a/docs/user/authentication.rst
+++ b/docs/user/authentication.rst
@@ -36,10 +36,9 @@ Providing the credentials in a tuple like this is exactly the same as the
 netrc Authentication
 ~~~~~~~~~~~~~~~~~~~~
 
-If no authentication method is given with the ``auth`` argument, Niquests will
-attempt to get the authentication credentials for the URL's hostname from the
-user's netrc file. The netrc file overrides raw HTTP authentication headers
-set with `headers=`.
+If no authentication method is given with the ``auth`` argument and the
+Authorization header has not been set, Requests will attempt to get the
+authentication credentials for the URL's hostname from the user's netrc file.
 
 If credentials for the hostname are found, the request is sent with HTTP Basic
 Auth.

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 
-__build__: int = 0x030103
+__build__: int = 0x030104
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -33,6 +33,7 @@ BodyType: typing.TypeAlias = typing.Union[
     typing.IO,
     BodyFormType,
     typing.Iterable[bytes],
+    typing.Iterable[str],
 ]
 #: HTTP Headers can be represented through three ways. 1) typical dict, 2) internal insensitive dict, and 3) list of tuple.
 HeadersType: typing.TypeAlias = typing.Union[

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -165,6 +165,10 @@ class Request:
         self.auth = auth
         self.cookies = cookies
 
+    @property
+    def oheaders(self) -> Headers:
+        return parse_it(self.headers)
+
     def __repr__(self) -> str:
         return f"<Request [{self.method}]>"
 

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -308,7 +308,11 @@ class Session:
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth
-        if self.trust_env and not auth and not self.auth:
+        has_authorization_set = (
+            "authorization" in self.headers or "authorization" in request.oheaders
+        )
+
+        if self.trust_env and not auth and not self.auth and not has_authorization_set:
             auth = get_netrc_auth(request.url)
 
         p = PreparedRequest()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -669,6 +669,9 @@ class TestRequests:
             r = niquests.get(url, auth=wrong_auth)
             assert r.status_code == 401
 
+            r = niquests.get(url, headers={"Authorization": "SHOULD DISCARD NETRC!"})
+            assert r.status_code == 401
+
             s = niquests.Session()
 
             # Should use netrc and work.
@@ -677,6 +680,11 @@ class TestRequests:
 
             # Given auth should override and fail.
             s.auth = wrong_auth
+            r = s.get(url)
+            assert r.status_code == 401
+
+            s.auth = None
+            s.headers["Authorization"] = "SHOULD DISCARD NETRC!"
             r = s.get(url)
             assert r.status_code == 401
         finally:


### PR DESCRIPTION
3.1.4 (2023-10-23)
------------------

**Fixed**
- Static type checker not accepting **iterable\[str\]** for **data**. A fix in urllib3.future allows it since v2.1.902.
- Unattended override of manually provided **Authorization** if `.netrc` existed with an eligible entry. Taken from closed PR https://github.com/psf/requests/pull/6555 and initially raised in https://github.com/psf/requests/issues/3929

**Added**
- **oheaders** property in `Request`, and `PreparedRequest` in addition to `Response`.