### PR TITLE
:bookmark: Release 3.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.1.902', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.2.901', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 **Niquests** is a simple, yet elegant, HTTP library. It is a drop-in replacement for **Requests** that is no longer under
 feature freeze.
 
-Why did we pursue this? We don't have to reinvent the wheel all over again, HTTP client **Requests** is well established and
-really plaisant in its usage. We believe that **Requests** have the most inclusive, and developer friendly interfaces. We
-intend to keep it that way.
+Niquests, is the “**Safest**, **Fastest**, **Easiest**, and **Most advanced**” Python HTTP Client.
 
 ```python
 >>> import niquests
@@ -28,8 +26,6 @@ True
 
 Niquests allows you to send HTTP requests extremely easily. There’s no need to manually add query strings to your URLs, or to form-encode your `PUT` & `POST` data — but nowadays, just use the `json` method!
 
-Niquests is one of the least downloaded Python packages today, pulling in around `100+ download / week`— according to GitHub, Niquests is currently depended upon by `1+` repositories. But, that may change..! Starting with you.
-
 [![Downloads](https://static.pepy.tech/badge/niquests/month)](https://pepy.tech/project/niquests)
 [![Supported Versions](https://img.shields.io/pypi/pyversions/niquests.svg)](https://pypi.org/project/niquests)
 
@@ -41,7 +37,7 @@ Niquests is available on PyPI:
 $ python -m pip install niquests
 ```
 
-Niquests officially supports Python 3.7+.
+Niquests officially supports Python or PyPy 3.7+.
 
 ## Supported Features & Best–Practices
 
@@ -66,6 +62,14 @@ Niquests is ready for the demands of building robust and reliable HTTP–speakin
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Multiplexed!
+- Async!
+
+## Why did we pursue this?
+
+We don't have to reinvent the wheel all over again, HTTP client **Requests** is well established and
+really plaisant in its usage. We believe that **Requests** have the most inclusive, and developer friendly interfaces.
+We intend to keep it that way. As long as we can, long live Niquests!
 
 ---
 

--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -18,7 +18,7 @@ whenever you're making a lot of web niquests.
 Requests-Toolbelt
 -----------------
 
-`Requests-Toolbelt`_ is a collection of utilities that some users of Requests may desire,
+`Requests-Toolbelt`_ is a collection of utilities that some users of Niquests may desire,
 but do not belong in Niquests proper. This library is actively maintained
 by members of the Requests core team, and reflects the functionality most
 requested by users within the community.

--- a/docs/community/vulnerabilities.rst
+++ b/docs/community/vulnerabilities.rst
@@ -86,16 +86,4 @@ if upgrading is not an option.
 Previous CVEs
 -------------
 
-- Fixed in 2.20.0
-  - `CVE 2018-18074 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-18074>`_
-
-- Fixed in 2.6.0
-
-  - `CVE 2015-2296 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=2015-2296>`_,
-    reported by Matthew Daley of `BugFuzz <https://bugfuzz.com/>`_.
-
-- Fixed in 2.3.0
-
-  - `CVE 2014-1829 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=2014-1829>`_
-
-  - `CVE 2014-1830 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=2014-1830>`_
+None to date.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,8 @@ Niquests is ready for today's web.
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Multiplexed!
+- Async!
 
 Niquests officially supports Python 3.7+, and runs great on PyPy.
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1228,3 +1228,26 @@ by passing a custom ``QuicSharedCache`` instance like so::
 .. note:: Passing ``None`` to max size actually permit the cache to grow indefinitely. This is unwise and can lead to significant RAM usage.
 
 When the cache is full, the oldest entry is removed.
+
+Disable HTTP/2, and/or HTTP/3
+-----------------------------
+
+You can at your own discretion disable a protocol by passing ``disable_http2=True`` or
+``disable_http3=True`` within your ``Session`` constructor.
+
+.. warning:: It is actually forbidden to disable HTTP/1.1 as the underlying library (urllib3.future) does not permit it for now.
+
+Having a session without HTTP/2 enabled should be done that way::
+
+    import niquests
+
+    session = niquests.Session(disable_http2=True)
+
+
+Passing a bearer token
+----------------------
+
+You may use ``auth=my_token`` as a shortcut to passing ``headers={"Authorization": f"Bearer {my_token}"}`` in
+get, post, request, etc...
+
+.. note:: If you pass a token with its custom prefix, it will be taken and passed as-is. e.g. ``auth="NotBearer eyDdx.."``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python HTTP for Humans."
 readme = "README.md"
 license-files = { paths = ["LICENSE"] }
 license = "Apache-2.0"
-keywords = ["requests", "http/2", "http/3", "QUIC", "http", "https", "http client", "http/1.1", "ocsp", "revocation", "tls"]
+keywords = ["requests", "http/2", "http/3", "QUIC", "http", "https", "http client", "http/1.1", "ocsp", "revocation", "tls", "multiplexed"]
 authors = [
   {name = "Kenneth Reitz", email = "me@kennethreitz.org"}
 ]
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.1.900,<3",
+    "urllib3.future>=2.2.901,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
@@ -51,7 +51,7 @@ socks = [
     "PySocks>=1.5.6, !=1.5.7",
 ]
 http3 = [
-    "qh3<1.0.0,>=0.11.3"
+    "qh3<1.0.0,>=0.13.0"
 ]
 ocsp = [
     "cryptography<42.0.0,>=41.0.0"
@@ -104,4 +104,5 @@ filterwarnings = [
     '''ignore:Passing bytes as a header value is deprecated and will:DeprecationWarning''',
     '''ignore:The 'JSONIFY_PRETTYPRINT_REGULAR' config key is deprecated and will:DeprecationWarning''',
     '''ignore:unclosed .*:ResourceWarning''',
+    '''ignore:Parsed a negative serial number:cryptography.utils.CryptographyDeprecationWarning''',
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 pytest>=2.8.0,<=7.4.2
 pytest-cov
 pytest-httpbin==2.0.0
+pytest-asyncio>=0.21.1,<1.0
 httpbin==0.10.1
 trustme
 wheel

--- a/src/niquests/__init__.py
+++ b/src/niquests/__init__.py
@@ -91,6 +91,7 @@ from .__version__ import (
     __url__,
     __version__,
 )
+from ._async import AsyncSession
 from .api import delete, get, head, options, patch, post, put, request
 from .exceptions import (
     ConnectionError,
@@ -146,4 +147,5 @@ __all__ = (
     "Response",
     "Session",
     "codes",
+    "AsyncSession",
 )

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.1.4"
+__version__ = "3.2.0"
 
-__build__: int = 0x030104
+__build__: int = 0x030200
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import typing
+
+from ._constant import READ_DEFAULT_TIMEOUT, WRITE_DEFAULT_TIMEOUT
+from ._typing import (
+    BodyType,
+    CookiesType,
+    HeadersType,
+    HookType,
+    HttpAuthenticationType,
+    HttpMethodType,
+    MultiPartFilesAltType,
+    MultiPartFilesType,
+    ProxyType,
+    QueryParameterType,
+    TimeoutType,
+    TLSClientCertType,
+    TLSVerifyType,
+)
+from .extensions._sync_to_async import sync_to_async
+from .hooks import dispatch_hook
+from .models import PreparedRequest, Request, Response
+from .sessions import Session
+
+
+class AsyncSession(Session):
+    """
+    "It's aint much, but its honest work" kind of class.
+    Use a thread pool under the carpet. It's not true async.
+    """
+
+    disable_thread: bool = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc, value, tb):
+        super().__exit__()
+
+    async def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response:  # type: ignore[override]
+        return await sync_to_async(
+            super().send,
+            thread_sensitive=AsyncSession.disable_thread,
+        )(request=request, **kwargs)
+
+    async def request(  # type: ignore[override]
+        self,
+        method: HttpMethodType,
+        url: str,
+        params: QueryParameterType | None = None,
+        data: BodyType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        stream: bool | None = None,
+        verify: TLSVerifyType | None = None,
+        cert: TLSClientCertType | None = None,
+        json: typing.Any | None = None,
+    ) -> Response:
+        if method.isupper() is False:
+            method = method.upper()
+
+        # Create the Request.
+        req = Request(
+            method=method,
+            url=url,
+            headers=headers,
+            files=files,
+            data=data or {},
+            json=json,
+            params=params or {},
+            auth=auth,
+            cookies=cookies,
+            hooks=hooks,
+        )
+
+        prep: PreparedRequest = dispatch_hook(
+            "pre_request", hooks, self.prepare_request(req)  # type: ignore[arg-type]
+        )
+
+        assert prep.url is not None
+
+        proxies = proxies or {}
+
+        settings = self.merge_environment_settings(
+            prep.url, proxies, stream, verify, cert
+        )
+
+        # Send the request.
+        send_kwargs = {
+            "timeout": timeout,
+            "allow_redirects": allow_redirects,
+        }
+        send_kwargs.update(settings)
+
+        return await self.send(prep, **send_kwargs)
+
+    async def get(  # type: ignore[override]
+        self,
+        url: str,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = READ_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def options(  # type: ignore[override]
+        self,
+        url: str,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = READ_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "OPTIONS",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def head(  # type: ignore[override]
+        self,
+        url: str,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = READ_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "HEAD",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def post(  # type: ignore[override]
+        self,
+        url: str,
+        data: BodyType | None = None,
+        json: typing.Any | None = None,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "POST",
+            url,
+            data=data,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def put(  # type: ignore[override]
+        self,
+        url: str,
+        data: BodyType | None = None,
+        *,
+        json: typing.Any | None = None,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "PUT",
+            url,
+            data=data,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def patch(  # type: ignore[override]
+        self,
+        url: str,
+        data: BodyType | None = None,
+        *,
+        json: typing.Any | None = None,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "PATCH",
+            url,
+            data=data,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def delete(  # type: ignore[override]
+        self,
+        url: str,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType = True,
+        stream: bool = False,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        return await self.request(
+            "DELETE",
+            url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
+        )
+
+    async def gather(self, *responses: Response) -> None:  # type: ignore[override]
+        return await sync_to_async(
+            super().gather,
+            thread_sensitive=AsyncSession.disable_thread,
+        )(*responses)

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -69,6 +69,7 @@ TimeoutType: typing.TypeAlias = typing.Union[
 #: Can be a custom authentication mechanism that derive from AuthBase.
 HttpAuthenticationType: typing.TypeAlias = typing.Union[
     typing.Tuple[typing.Union[str, bytes], typing.Union[str, bytes]],
+    str,
     AuthBase,
 ]
 #: Map for each protocol (http, https) associated proxy to be used.

--- a/src/niquests/auth.py
+++ b/src/niquests/auth.py
@@ -46,6 +46,29 @@ class AuthBase:
         raise NotImplementedError("Auth hooks must be callable.")
 
 
+class BearerTokenAuth(AuthBase):
+    """Simple token injection in Authorization header"""
+
+    def __init__(self, token: str):
+        self.token = token
+
+    def __eq__(self, other) -> bool:
+        return self.token == getattr(other, "token", None)
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+    def __call__(self, r):
+        detect_token_type: list[str] = self.token.split(" ", maxsplit=1)
+
+        if len(detect_token_type) == 1:
+            r.headers["Authorization"] = f"Bearer {self.token}"
+        else:
+            r.headers["Authorization"] = self.token
+
+        return r
+
+
 class HTTPBasicAuth(AuthBase):
     """Attaches HTTP Basic Authentication to the given Request object."""
 

--- a/src/niquests/exceptions.py
+++ b/src/niquests/exceptions.py
@@ -139,6 +139,10 @@ class UnrewindableBodyError(RequestException):
     """Requests encountered an error when trying to rewind a body."""
 
 
+class MultiplexingError(RequestException):
+    """Requests encountered an unresolvable error in multiplexed mode."""
+
+
 # Warnings
 
 

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -61,6 +61,10 @@ def _infer_issuer_from(certificate: Certificate) -> Certificate | None:
         else:
             possible_issuer = load_der_x509_certificate(der_cert)
 
+        # detect cryptography old build
+        if not hasattr(certificate, "verify_directly_issued_by"):
+            break
+
         try:
             certificate.verify_directly_issued_by(possible_issuer)
         except ValueError:
@@ -402,7 +406,7 @@ def verify(
                 if issuer_certificate is not None:
                     peer_certificate.verify_directly_issued_by(issuer_certificate)
 
-            except (socket.gaierror, TimeoutError, ConnectionError):
+            except (socket.gaierror, TimeoutError, ConnectionError, AttributeError):
                 pass
             except ValueError:
                 issuer_certificate = None

--- a/src/niquests/extensions/_sync_to_async.py
+++ b/src/niquests/extensions/_sync_to_async.py
@@ -1,0 +1,534 @@
+"""
+Copyright (c) Django Software Foundation and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import asyncio.coroutines
+import contextvars
+import functools
+import inspect
+import os
+import sys
+import threading
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Coroutine, Generic, TypeVar, overload
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing import _type_check
+
+    class _Immutable:
+        """Mixin to indicate that object should not be copied."""
+
+        __slots__ = ()
+
+        def __copy__(self):
+            return self
+
+        def __deepcopy__(self, memo):
+            return self
+
+    class ParamSpecArgs(_Immutable):
+        """The args for a ParamSpec object.
+
+        Given a ParamSpec object P, P.args is an instance of ParamSpecArgs.
+
+        ParamSpecArgs objects have a reference back to their ParamSpec:
+
+        P.args.__origin__ is P
+
+        This type is meant for runtime introspection and has no special meaning to
+        static type checkers.
+        """
+
+        def __init__(self, origin):
+            self.__origin__ = origin
+
+        def __repr__(self):
+            return f"{self.__origin__.__name__}.args"
+
+        def __eq__(self, other):
+            if not isinstance(other, ParamSpecArgs):
+                return NotImplemented
+            return self.__origin__ == other.__origin__
+
+    class ParamSpecKwargs(_Immutable):
+        """The kwargs for a ParamSpec object.
+
+        Given a ParamSpec object P, P.kwargs is an instance of ParamSpecKwargs.
+
+        ParamSpecKwargs objects have a reference back to their ParamSpec:
+
+        P.kwargs.__origin__ is P
+
+        This type is meant for runtime introspection and has no special meaning to
+        static type checkers.
+        """
+
+        def __init__(self, origin):
+            self.__origin__ = origin
+
+        def __repr__(self):
+            return f"{self.__origin__.__name__}.kwargs"
+
+        def __eq__(self, other):
+            if not isinstance(other, ParamSpecKwargs):
+                return NotImplemented
+            return self.__origin__ == other.__origin__
+
+    def _set_default(type_param, default):
+        if isinstance(default, (tuple, list)):
+            type_param.__default__ = tuple(
+                _type_check(d, "Default must be a type") for d in default
+            )
+        elif default != _marker:
+            type_param.__default__ = _type_check(default, "Default must be a type")
+        else:
+            type_param.__default__ = None
+
+    class _DefaultMixin:
+        """Mixin for TypeVarLike defaults."""
+
+        __slots__ = ()
+        __init__ = _set_default
+
+    def _caller(depth=2):
+        try:
+            return sys._getframe(depth).f_globals.get("__name__", "__main__")
+        except (AttributeError, ValueError):  # For platforms without _getframe()
+            return None
+
+    class _Sentinel:
+        def __repr__(self):
+            return "<sentinel>"
+
+    _marker = _Sentinel()
+
+    # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
+    class ParamSpec(list, _DefaultMixin):
+        """Parameter specification variable.
+
+        Usage::
+
+           P = ParamSpec('P')
+
+        Parameter specification variables exist primarily for the benefit of static
+        type checkers.  They are used to forward the parameter types of one
+        callable to another callable, a pattern commonly found in higher order
+        functions and decorators.  They are only valid when used in ``Concatenate``,
+        or s the first argument to ``Callable``. In Python 3.10 and higher,
+        they are also supported in user-defined Generics at runtime.
+        See class Generic for more information on generic types.  An
+        example for annotating a decorator::
+
+           T = TypeVar('T')
+           P = ParamSpec('P')
+
+           def add_logging(f: Callable[P, T]) -> Callable[P, T]:
+               '''A type-safe decorator to add logging to a function.'''
+               def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                   logging.info(f'{f.__name__} was called')
+                   return f(*args, **kwargs)
+               return inner
+
+           @add_logging
+           def add_two(x: float, y: float) -> float:
+               '''Add two numbers together.'''
+               return x + y
+
+        Parameter specification variables defined with covariant=True or
+        contravariant=True can be used to declare covariant or contravariant
+        generic types.  These keyword arguments are valid, but their actual semantics
+        are yet to be decided.  See PEP 612 for details.
+
+        Parameter specification variables can be introspected. e.g.:
+
+           P.__name__ == 'T'
+           P.__bound__ == None
+           P.__covariant__ == False
+           P.__contravariant__ == False
+
+        Note that only parameter specification variables defined in global scope can
+        be pickled.
+        """
+
+        # Trick Generic __parameters__.
+        __class__ = TypeVar
+
+        @property
+        def args(self):
+            return ParamSpecArgs(self)
+
+        @property
+        def kwargs(self):
+            return ParamSpecKwargs(self)
+
+        def __init__(
+            self,
+            name,
+            *,
+            bound=None,
+            covariant=False,
+            contravariant=False,
+            infer_variance=False,
+            default=_marker,
+        ):
+            super().__init__([self])
+            self.__name__ = name
+            self.__covariant__ = bool(covariant)
+            self.__contravariant__ = bool(contravariant)
+            self.__infer_variance__ = bool(infer_variance)
+            if bound:
+                self.__bound__ = _type_check(bound, "Bound must be a type.")
+            else:
+                self.__bound__ = None
+            _DefaultMixin.__init__(self, default)
+
+            # for pickling:
+            def_mod = _caller()
+            if def_mod != "typing_extensions":
+                self.__module__ = def_mod
+
+        def __repr__(self):
+            if self.__infer_variance__:
+                prefix = ""
+            elif self.__covariant__:
+                prefix = "+"
+            elif self.__contravariant__:
+                prefix = "-"
+            else:
+                prefix = "~"
+            return prefix + self.__name__
+
+        def __hash__(self):
+            return object.__hash__(self)
+
+        def __eq__(self, other):
+            return self is other
+
+        def __reduce__(self):
+            return self.__name__
+
+        # Hack to get typing._type_check to pass.
+        def __call__(self, *args, **kwargs):
+            pass
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _restore_context(context: contextvars.Context) -> None:
+    # Check for changes in contextvars, and set them to the current
+    # context for downstream consumers
+    for cvar in context:
+        cvalue = context.get(cvar)
+        try:
+            if cvar.get() != cvalue:
+                cvar.set(cvalue)
+        except LookupError:
+            cvar.set(cvalue)
+
+
+# Python 3.12 deprecates asyncio.iscoroutinefunction() as an alias for
+# inspect.iscoroutinefunction(), whilst also removing the _is_coroutine marker.
+# The latter is replaced with the inspect.markcoroutinefunction decorator.
+# Until 3.12 is the minimum supported Python version, provide a shim.
+# Django 4.0 only supports 3.8+, so don't concern with the _or_partial backport.
+
+if hasattr(inspect, "markcoroutinefunction"):
+    iscoroutinefunction = inspect.iscoroutinefunction
+    markcoroutinefunction: Callable[[_F], _F] = inspect.markcoroutinefunction
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction  # type: ignore[assignment]
+
+    def markcoroutinefunction(func: _F) -> _F:
+        func._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore
+        return func
+
+
+if sys.version_info >= (3, 8):
+    _iscoroutinefunction_or_partial = iscoroutinefunction
+else:
+
+    def _iscoroutinefunction_or_partial(func: Any) -> bool:
+        # Python < 3.8 does not correctly determine partially wrapped
+        # coroutine functions are coroutine functions, hence the need for
+        # this to exist. Code taken from CPython.
+        while inspect.ismethod(func):
+            func = func.__func__
+        while isinstance(func, functools.partial):
+            func = func.func
+
+        return iscoroutinefunction(func)
+
+
+class ThreadSensitiveContext:
+    """Async context manager to manage context for thread sensitive mode
+
+    This context manager controls which thread pool executor is used when in
+    thread sensitive mode. By default, a single thread pool executor is shared
+    within a process.
+
+    In Python 3.7+, the ThreadSensitiveContext() context manager may be used to
+    specify a thread pool per context.
+
+    This context manager is re-entrant, so only the outer-most call to
+    ThreadSensitiveContext will set the context.
+
+    Usage:
+
+    >>> import time
+    >>> async with ThreadSensitiveContext():
+    ...     await sync_to_async(time.sleep, 1)()
+    """
+
+    def __init__(self):
+        self.token = None
+
+    async def __aenter__(self):
+        try:
+            SyncToAsync.thread_sensitive_context.get()
+        except LookupError:
+            self.token = SyncToAsync.thread_sensitive_context.set(self)
+
+        return self
+
+    async def __aexit__(self, exc, value, tb):
+        if not self.token:
+            return
+
+        executor = SyncToAsync.context_to_thread_executor.pop(self, None)
+        if executor:
+            executor.shutdown()
+        SyncToAsync.thread_sensitive_context.reset(self.token)
+
+
+class SyncToAsync(Generic[_P, _R]):
+    """
+    Utility class which turns a synchronous callable into an awaitable that
+    runs in a threadpool. It also sets a threadlocal inside the thread so
+    calls to AsyncToSync can escape it.
+
+    If thread_sensitive is passed, the code will run in the same thread as any
+    outer code. This is needed for underlying Python code that is not
+    threadsafe (for example, code which handles SQLite database connections).
+
+    If the outermost program is async (i.e. SyncToAsync is outermost), then
+    this will be a dedicated single sub-thread that all sync code runs in,
+    one after the other. If the outermost program is sync (i.e. AsyncToSync is
+    outermost), this will just be the main thread. This is achieved by idling
+    with a CurrentThreadExecutor while AsyncToSync is blocking its sync parent,
+    rather than just blocking.
+
+    If executor is passed in, that will be used instead of the loop's default executor.
+    In order to pass in an executor, thread_sensitive must be set to False, otherwise
+    a TypeError will be raised.
+    """
+
+    # Storage for main event loop references
+    threadlocal = threading.local()
+
+    # Single-thread executor for thread-sensitive code
+    single_thread_executor = ThreadPoolExecutor(max_workers=1)
+
+    # Maintain a contextvar for the current execution context. Optionally used
+    # for thread sensitive mode.
+    thread_sensitive_context: contextvars.ContextVar[
+        ThreadSensitiveContext
+    ] = contextvars.ContextVar("thread_sensitive_context")
+
+    # Contextvar that is used to detect if the single thread executor
+    # would be awaited on while already being used in the same context
+    deadlock_context: contextvars.ContextVar[bool] = contextvars.ContextVar(
+        "deadlock_context"
+    )
+
+    # Maintaining a weak reference to the context ensures that thread pools are
+    # erased once the context goes out of scope. This terminates the thread pool.
+    context_to_thread_executor: weakref.WeakKeyDictionary[
+        ThreadSensitiveContext, ThreadPoolExecutor
+    ] = weakref.WeakKeyDictionary()
+
+    def __init__(
+        self,
+        func: Callable[_P, _R],
+        thread_sensitive: bool = False,
+        executor: ThreadPoolExecutor | None = None,
+    ) -> None:
+        if (
+            not callable(func)
+            or _iscoroutinefunction_or_partial(func)
+            or _iscoroutinefunction_or_partial(getattr(func, "__call__", func))
+        ):
+            raise TypeError("sync_to_async can only be applied to sync functions.")
+        self.func = func
+        functools.update_wrapper(self, func)
+        self._thread_sensitive = thread_sensitive
+        markcoroutinefunction(self)
+        if thread_sensitive and executor is not None:
+            raise TypeError("executor must not be set when thread_sensitive is True")
+        self._executor = executor
+        try:
+            self.__self__ = func.__self__  # type: ignore
+        except AttributeError:
+            pass
+
+    async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        __traceback_hide__ = True  # noqa: F841
+        loop = asyncio.get_running_loop()
+
+        # Work out what thread to run the code in
+        if self._thread_sensitive:
+            if self.thread_sensitive_context.get(None):
+                # If we have a way of retrieving the current context, attempt
+                # to use a per-context thread pool executor
+                thread_sensitive_context = self.thread_sensitive_context.get()
+
+                if thread_sensitive_context in self.context_to_thread_executor:
+                    # Re-use thread executor in current context
+                    executor = self.context_to_thread_executor[thread_sensitive_context]
+                else:
+                    # Create new thread executor in current context
+                    executor = ThreadPoolExecutor(max_workers=1)
+                    self.context_to_thread_executor[thread_sensitive_context] = executor
+            elif self.deadlock_context.get(False):
+                raise RuntimeError(
+                    "Single thread executor already being used, would deadlock"
+                )
+            else:
+                # Otherwise, we run it in a fixed single thread
+                executor = self.single_thread_executor
+                self.deadlock_context.set(True)
+        else:
+            # Use the passed in executor, or the loop's default if it is None
+            executor = self._executor  # type: ignore[assignment]
+
+        context = contextvars.copy_context()
+        child = functools.partial(self.func, *args, **kwargs)
+        func = context.run
+
+        try:
+            # Run the code in the right thread
+            ret: _R = await loop.run_in_executor(
+                executor,
+                functools.partial(
+                    self.thread_handler,
+                    loop,
+                    sys.exc_info(),
+                    func,
+                    child,
+                ),
+            )
+
+        finally:
+            _restore_context(context)
+            self.deadlock_context.set(False)
+
+        return ret
+
+    def __get__(
+        self, parent: Any, objtype: Any
+    ) -> Callable[_P, Coroutine[Any, Any, _R]]:
+        """
+        Include self for methods
+        """
+        func = functools.partial(self.__call__, parent)
+        return functools.update_wrapper(func, self.func)
+
+    def thread_handler(self, loop, exc_info, func, *args, **kwargs):
+        """
+        Wraps the sync application with exception handling.
+        """
+
+        __traceback_hide__ = True  # noqa: F841
+
+        # Set the threadlocal for AsyncToSync
+        self.threadlocal.main_event_loop = loop
+        self.threadlocal.main_event_loop_pid = os.getpid()
+
+        # Run the function
+        # If we have an exception, run the function inside the except block
+        # after raising it so exc_info is correctly populated.
+        if exc_info[1]:
+            try:
+                raise exc_info[1]
+            except BaseException:
+                return func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
+
+@overload
+def sync_to_async(
+    *,
+    thread_sensitive: bool = True,
+    executor: ThreadPoolExecutor | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]]:
+    ...
+
+
+@overload
+def sync_to_async(
+    func: Callable[_P, _R],
+    *,
+    thread_sensitive: bool = True,
+    executor: ThreadPoolExecutor | None = None,
+) -> Callable[_P, Coroutine[Any, Any, _R]]:
+    ...
+
+
+def sync_to_async(
+    func: Callable[_P, _R] | None = None,
+    *,
+    thread_sensitive: bool = False,
+    executor: ThreadPoolExecutor | None = None,
+) -> (
+    Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]]
+    | Callable[_P, Coroutine[Any, Any, _R]]
+):
+    if func is None:
+        return lambda f: SyncToAsync(
+            f,
+            thread_sensitive=thread_sensitive,
+            executor=executor,
+        )
+    return SyncToAsync(
+        func,
+        thread_sensitive=thread_sensitive,
+        executor=executor,
+    )
+
+
+__all__ = ("sync_to_async",)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from niquests import AsyncSession
+
+
+@pytest.mark.usefixtures("requires_wan")
+@pytest.mark.asyncio
+class TestAsyncWithoutMultiplex:
+    async def test_awaitable_get(self):
+        async with AsyncSession() as s:
+            resp = await s.get("https://pie.dev/get")
+
+            assert resp.lazy is False
+            assert resp.status_code == 200
+
+    async def test_concurrent_task_get(self):
+        async def emit():
+            responses = []
+
+            async with AsyncSession() as s:
+                responses.append(await s.get("https://pie.dev/get"))
+                responses.append(await s.get("https://pie.dev/delay/5"))
+
+            return responses
+
+        foo = asyncio.create_task(emit())
+        bar = asyncio.create_task(emit())
+
+        responses_foo = await foo
+        responses_bar = await bar
+
+        assert len(responses_foo) == 2
+        assert len(responses_bar) == 2
+
+        assert all(r.status_code == 200 for r in responses_foo + responses_bar)
+
+
+@pytest.mark.usefixtures("requires_wan")
+@pytest.mark.asyncio
+class TestAsyncWithMultiplex:
+    async def test_awaitable_get(self):
+        async with AsyncSession(multiplexed=True) as s:
+            resp = await s.get("https://pie.dev/get")
+
+            assert resp.lazy is True
+            await s.gather()
+
+            assert resp.status_code == 200
+
+    async def test_awaitable_get_direct_access_lazy(self):
+        async with AsyncSession(multiplexed=True) as s:
+            resp = await s.get("https://pie.dev/get")
+
+            assert resp.lazy is True
+            assert resp.status_code == 200
+
+    async def test_concurrent_task_get(self):
+        async def emit():
+            responses = []
+
+            async with AsyncSession(multiplexed=True) as s:
+                responses.append(await s.get("https://pie.dev/get"))
+                responses.append(await s.get("https://pie.dev/delay/5"))
+
+                await s.gather()
+
+            return responses
+
+        foo = asyncio.create_task(emit())
+        bar = asyncio.create_task(emit())
+
+        responses_foo = await foo
+        responses_bar = await bar
+
+        assert len(responses_foo) == 2
+        assert len(responses_bar) == 2
+
+        assert all(r.status_code == 200 for r in responses_foo + responses_bar)

--- a/tests/test_multiplexed.py
+++ b/tests/test_multiplexed.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from niquests import Session
+
+
+@pytest.mark.usefixtures("requires_wan")
+class TestMultiplexed:
+    def test_concurrent_request_in_sync(self):
+        responses = []
+
+        with Session(multiplexed=True) as s:
+            responses.append(s.get("https://pie.dev/delay/3"))
+            responses.append(s.get("https://pie.dev/delay/1"))
+            responses.append(s.get("https://pie.dev/delay/1"))
+            responses.append(s.get("https://pie.dev/delay/3"))
+
+            assert all(r.lazy for r in responses)
+
+            s.gather()
+
+        assert all(r.lazy is False for r in responses)
+        assert all(r.status_code == 200 for r in responses)
+
+    def test_redirect_with_multiplexed(self):
+        with Session(multiplexed=True) as s:
+            resp = s.get("https://pie.dev/redirect/3")
+            assert resp.lazy
+            s.gather()
+
+            assert resp.status_code == 200
+            assert resp.url == "https://pie.dev/get"
+            assert len(resp.history) == 3
+
+    def test_lazy_access_sync_mode(self):
+        with Session(multiplexed=True) as s:
+            resp = s.get("https://pie.dev/headers")
+            assert resp.lazy
+
+            assert resp.status_code == 200
+
+    def test_post_data_with_multiplexed(self):
+        responses = []
+
+        with Session(multiplexed=True) as s:
+            for i in range(5):
+                responses.append(
+                    s.post(
+                        "https://pie.dev/post",
+                        data=b"foo" * 128,
+                    )
+                )
+
+            s.gather()
+
+        assert all(r.lazy is False for r in responses)
+        assert all(r.status_code == 200 for r in responses)
+        assert all(r.json()["data"] == "foo" * 128 for r in responses)
+
+    def test_get_stream_with_multiplexed(self):
+        with Session(multiplexed=True) as s:
+            resp = s.get("https://pie.dev/headers", stream=True)
+            assert resp.lazy
+
+            assert resp.status_code == 200
+            assert resp._content_consumed is False
+
+            payload = b""
+
+            for chunk in resp.iter_content(32):
+                payload += chunk
+
+            assert resp._content_consumed is True
+
+            import json
+
+            assert isinstance(json.loads(payload), dict)


### PR DESCRIPTION
3.2.0 (2023-11-05)
------------------

**Changed**
- Changed method `raise_for_status` in class `Response` to return **self** in order to make the call chainable.
  Idea taken from upstream https://github.com/psf/requests/issues/6215
- Bump minimal version supported for `urllib3.future` to 2.2.901 for recently introduced added features (bellow).

**Added**
- Support for multiplexed connection in HTTP/2 and HTTP/3. Concurrent requests per connection are now a thing, in synchronous code.
  This feature is the real advantage of using binaries HTTP protocols.
  It is disabled by default and can be enabled through `Session(multiplexed=True)`, each `Response` object will
  be 'lazy' loaded. Accessing anything from returned `Response` will block the code until target response is retrieved.
  Use `Session.gather()` to efficiently receive responses. You may also give a list of responses that you want to load.

  **Example A)** Emitting concurrent requests and loading them via `Session.gather()`
  ```python
  from niquests import Session
  from time import time

  s = Session(multiplexed=True)

  before = time()
  responses = []

  responses.append(
    s.get("https://pie.dev/delay/3")
  )

  responses.append(
    s.get("https://pie.dev/delay/1")
  )

  s.gather()

  print(f"waited {time() - before} second(s)")  # will print 3s
  ```

  **Example B)** Emitting concurrent requests and loading them via direct access
  ```python
  from niquests import Session
  from time import time

  s = Session(multiplexed=True)

  before = time()
  responses = []

  responses.append(
    s.get("https://pie.dev/delay/3")
  )

  responses.append(
    s.get("https://pie.dev/delay/1")
  )

  # internally call gather with self (Response)
  print(responses[0].status_code)  # 200! :! Hidden call to s.gather(responses[0])
  print(responses[1].status_code)  # 200!

  print(f"waited {time() - before} second(s)")  # will print 3s
  ```
  You have nothing to do, everything from streams to connection pooling are handled automagically!
- Support for in-memory intermediary/client certificate (mTLS).
  Thanks for support within `urllib3.future`. Unfortunately this feature may not be available depending on your platform.
  Passing `cert=(a, b, c)` where **a** or/and **b** contains directly the certificate is supported.
  See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#in-memory-client-mtls-certificate for more information.
  It is proposed to circumvent recent pyOpenSSL complete removal.
- Detect if a new (stable) version is available when invoking `python -m niquests.help` and propose it for installation.
- Add the possibility to disable a specific protocol (e.g. HTTP/2, and/or HTTP/3) when constructing `Session`.
  Like so: `s = Session(disable_http2=..., disable_http3=...)` both options are set to `False`, thus letting them enabled.
  urllib3.future does not permit to disable HTTP/1.1 for now.
- Support passing a single `str` to `auth=...` in addition to actually supported types. It will be treated as a
  **Bearer** token, by default to the `Authorization` header. It's a shortcut. You may keep your own token prefix in given
  string (e.g. if not Bearer).
- Added `MultiplexingError` exception for anything related to failure with a multiplexed connection.
- Added **async** support through `AsyncSession` that utilize an underlying thread pool.
  ```python
  from niquests import AsyncSession
  import asyncio
  from time import time

  async def emit() -> None:
      responses = []

      async with AsyncSession(multiplexed=True) as s:
          responses.append(await s.get("https://pie.dev/get"))
          responses.append(await s.get("https://pie.dev/head"))

          await s.gather()

      print(responses)

  async def main() -> None:
      foo = asyncio.create_task(emit())
      bar = asyncio.create_task(emit())
      await foo
      await bar

  if __name__ == "__main__":
      before = time()
      asyncio.run(main())
      print(time() - before)
  ```
  Or without `multiplexing` if you want to keep multiple connections open per host per request.
  ```python
  from niquests import AsyncSession
  import asyncio
  from time import time

  async def emit() -> None:
      responses = []

      async with AsyncSession() as s:
          responses.append(await s.get("https://pie.dev/get"))
          responses.append(await s.get("https://pie.dev/head"))

      print(responses)

  async def main() -> None:
      foo = asyncio.create_task(emit())
      bar = asyncio.create_task(emit())
      await foo
      await bar

  if __name__ == "__main__":
      before = time()
      asyncio.run(main())
      print(time() - before)
  ```
  You may disable concurrent threads by setting `AsyncSession.no_thread = True`.

**Security**
- Certificate revocation verification may not be fired for subsequents requests in a specific condition (redirection).
