### PR TITLE
:bookmark: Release 3.2.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,16 @@
 Release History
 ===============
 
+3.2.1 (2023-11-06)
+------------------
+
+**Fixed**
+- Performance issues in HTTP/2, and HTTP/3, with or without multiplexed connections.
+
+**Changed**
+- Enforced a maximum in-flight request when using multiplexed connections. Default to 200 per connections
+  so, actually 2000 per Session (_default is 10 connections_). This can be overriden in our `HTTPAdapter` for advanced users.
+
 3.2.0 (2023-11-05)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Niquests** is a simple, yet elegant, HTTP library. It is a drop-in replacement for **Requests** that is no longer under
 feature freeze.
 
-Niquests, is the “**Safest**, **Fastest**, **Easiest**, and **Most advanced**” Python HTTP Client.
+Niquests, is the “**Safest**, **Fastest<sup>*</sup>**, **Easiest**, and **Most advanced**” Python HTTP Client.
 
 ```python
 >>> import niquests
@@ -70,6 +70,10 @@ Niquests is ready for the demands of building robust and reliable HTTP–speakin
 We don't have to reinvent the wheel all over again, HTTP client **Requests** is well established and
 really plaisant in its usage. We believe that **Requests** have the most inclusive, and developer friendly interfaces.
 We intend to keep it that way. As long as we can, long live Niquests!
+
+---
+
+<small><sup>(*)</sup> performance measured when leveraging a multiplexed connection with or without uses of any form of concurrency as of november 2023.</small>
 
 ---
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
-__build__: int = 0x030200
+__build__: int = 0x030201
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"


### PR DESCRIPTION
3.2.1 (2023-11-06)
--------------------------

**Fixed**
- Performance issues in HTTP/2, and HTTP/3, with or without multiplexed connections.

**Changed**
- Enforced a maximum in-flight request when using multiplexed connections. Default to 200 per connection so, actually 2000 per Session (_default is 10 connections_). This can be overridden in our `HTTPAdapter` for advanced users.

