### PR TITLE
:bookmark: Release 3.2.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,19 @@
 Release History
 ===============
 
+3.2.2 (2023-11-08)
+------------------
+
+**Changed**
+- Enforced a maximum in-flight request when using multiplexed connections. Default to 124 per connections
+  so, actually 1240 per Session (_default is 10 connections_). This can be overriden in our `HTTPAdapter` for advanced users.
+  This limit was changed due to constraint in `qh3`, for now we have no way to dynamically set this. We choose the safest
+  lowest common value in h2, and qh3.
+
+**Fixed**
+- Performance issues in `get_environ_proxies()`.
+
+
 3.2.1 (2023-11-06)
 ------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
-__build__: int = 0x030201
+__build__: int = 0x030202
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -222,7 +222,7 @@ class HTTPAdapter(BaseAdapter):
         self._max_in_flight_multiplexed = (
             max_in_flight_multiplexed
             if max_in_flight_multiplexed is not None
-            else self._pool_connections * 200
+            else self._pool_connections * 124
         )
 
         disabled_svn = set()

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -750,10 +750,15 @@ def get_environ_proxies(url: str, no_proxy: str | None = None) -> dict[str, str]
     """
     Return a dict of environment proxies.
     """
+    proxies = getproxies()
+
+    if not proxies:
+        return {}
+
     if should_bypass_proxies(url, no_proxy=no_proxy):
         return {}
     else:
-        return getproxies()
+        return proxies
 
 
 def select_proxy(


### PR DESCRIPTION
**Changed**
- Enforced a maximum in-flight request when using multiplexed connections. Default to 124 per connections so, actually 1240 per Session (_default is 10 connections_). This can be overriden in our `HTTPAdapter` for advanced users. This limit was changed due to constraint in `qh3`, for now we have no way to dynamically set this. We choose the safest lowest common value in h2, and qh3.

**Fixed**
- Performance issues in `get_environ_proxies()`.