### PR TITLE
:bookmark: Release 3.3.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github:
+  - Ousret

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,4 +32,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.2.901', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.3.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,25 @@
 Release History
 ===============
 
+3.3.0 (2023-11-18)
+------------------
+
+**Added**
+- Maximum of (lazy) response(s) to be resolved when calling `Session.gather(..., max_fetch = ...)`.
+  Specifying a valid int to `max_fetch` will stop right after having resolved the right amount of responses.
+
+**Changed**
+- urllib3.future minimal version raised to 2.3.900 to leverage the fallback top-level package `urllib3_future`.
+
+**Fixed**
+- Error when having accidentally overriden `urllib3.future` by an external dependency.
+- Undesirable warning yielded by `cryptography` because of a Microsoft root certificate.
+  "Parsed a negative serial number, which is disallowed by RFC 5280."
+- Take into account newly registered custom CA when using `wassima.register_ca(...)`.
+
+**Removed**
+- Dependency check at runtime for `urllib3`. There's no more check and warnings at runtime for that subject. Ever.
+
 3.2.4 (2023-11-15)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.2.901,<3",
+    "urllib3.future>=2.3.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.2.4"
+__version__ = "3.3.0"
 
-__build__: int = 0x030204
+__build__: int = 0x030300
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -343,8 +343,8 @@ class AsyncSession(Session):
             cert=cert,
         )
 
-    async def gather(self, *responses: Response) -> None:  # type: ignore[override]
+    async def gather(self, *responses: Response, max_fetch: int | None = None) -> None:  # type: ignore[override]
         return await sync_to_async(
             super().gather,
             thread_sensitive=AsyncSession.disable_thread,
-        )(*responses)
+        )(*responses, max_fetch=max_fetch)

--- a/src/niquests/_compat.py
+++ b/src/niquests/_compat.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+try:
+    from urllib3._version import __version__
+
+    HAS_LEGACY_URLLIB3: bool = int(__version__.split(".")[-1]) < 900
+except (ValueError, ImportError):
+    HAS_LEGACY_URLLIB3 = True

--- a/src/niquests/_constant.py
+++ b/src/niquests/_constant.py
@@ -13,4 +13,5 @@ DEFAULT_POOLBLOCK: bool = False
 DEFAULT_POOLSIZE: int = 10
 DEFAULT_RETRIES: RetryType = 0
 
+#: Kept for BC
 DEFAULT_CA_BUNDLE: str = wassima.generate_ca_bundle()

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -4,8 +4,15 @@ import typing
 from http.cookiejar import CookieJar
 
 from kiss_headers import Headers
-from urllib3 import Retry, Timeout
-from urllib3.fields import RequestField
+
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3 import Retry, Timeout
+    from urllib3.fields import RequestField
+else:
+    from urllib3_future import Retry, Timeout  # type: ignore[assignment]
+    from urllib3_future.fields import RequestField  # type: ignore[assignment]
 
 from .auth import AuthBase
 from .structures import CaseInsensitiveDict

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -19,7 +19,12 @@ from http.cookiejar import CookieJar
 from http.cookies import Morsel
 from urllib.parse import urlparse, urlunparse
 
-from urllib3 import BaseHTTPResponse
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3 import BaseHTTPResponse
+else:
+    from urllib3_future import BaseHTTPResponse  # type: ignore[assignment]
 
 from ._internal_utils import to_native_string
 

--- a/src/niquests/exceptions.py
+++ b/src/niquests/exceptions.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 import typing
 from json import JSONDecodeError as CompatJSONDecodeError
 
-from urllib3.exceptions import HTTPError as BaseHTTPError
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3.exceptions import HTTPError as BaseHTTPError
+else:
+    from urllib3_future.exceptions import HTTPError as BaseHTTPError  # type: ignore
 
 if typing.TYPE_CHECKING:
     from .models import PreparedRequest, Response

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -18,9 +18,17 @@ from cryptography.x509 import (
     load_pem_x509_certificate,
     ocsp,
 )
-from urllib3 import ConnectionInfo
-from urllib3.exceptions import SecurityWarning
-from urllib3.util.url import parse_url
+
+from .._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3 import ConnectionInfo
+    from urllib3.exceptions import SecurityWarning
+    from urllib3.util.url import parse_url
+else:
+    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
+    from urllib3_future.exceptions import SecurityWarning  # type: ignore[assignment]
+    from urllib3_future.util.url import parse_url  # type: ignore[assignment]
 
 from .._typing import ProxyType
 from ..exceptions import RequestException, SSLError

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -12,12 +12,17 @@ import charset_normalizer
 import h2  # type: ignore
 import h11
 import idna
-import urllib3
 import wassima
 
 from . import RequestException
 from . import __version__ as niquests_version
 from . import get
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is True:
+    import urllib3_future as urllib3
+else:
+    import urllib3  # type: ignore[no-redef]
 
 try:
     import qh3  # type: ignore

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -23,17 +23,33 @@ from urllib.parse import urlencode, urlsplit, urlunparse
 
 from charset_normalizer import from_bytes
 from kiss_headers import Headers, parse_it
-from urllib3 import BaseHTTPResponse, ConnectionInfo, ResponsePromise
-from urllib3.exceptions import (
-    DecodeError,
-    LocationParseError,
-    ProtocolError,
-    ReadTimeoutError,
-    SSLError,
-)
-from urllib3.fields import RequestField
-from urllib3.filepost import choose_boundary, encode_multipart_formdata
-from urllib3.util import parse_url
+
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3 import BaseHTTPResponse, ConnectionInfo, ResponsePromise
+    from urllib3.exceptions import (
+        DecodeError,
+        LocationParseError,
+        ProtocolError,
+        ReadTimeoutError,
+        SSLError,
+    )
+    from urllib3.fields import RequestField
+    from urllib3.filepost import choose_boundary, encode_multipart_formdata
+    from urllib3.util import parse_url
+else:
+    from urllib3_future import BaseHTTPResponse, ConnectionInfo, ResponsePromise  # type: ignore[assignment]
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
+        DecodeError,
+        LocationParseError,
+        ProtocolError,
+        ReadTimeoutError,
+        SSLError,
+    )
+    from urllib3_future.fields import RequestField  # type: ignore[assignment]
+    from urllib3_future.filepost import choose_boundary, encode_multipart_formdata  # type: ignore[assignment]
+    from urllib3_future.util import parse_url  # type: ignore[assignment]
 
 from ._internal_utils import to_native_string
 from ._typing import (

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -31,7 +31,12 @@ from urllib.request import (  # type: ignore[attr-defined]
     proxy_bypass_environment,
 )
 
-from urllib3.util import make_headers, parse_url
+from ._compat import HAS_LEGACY_URLLIB3
+
+if HAS_LEGACY_URLLIB3 is False:
+    from urllib3.util import make_headers, parse_url
+else:
+    from urllib3_future.util import make_headers, parse_url  # type: ignore[assignment]
 
 from .__version__ import __version__
 


### PR DESCRIPTION
3.3.0 (2023-11-18)
------------------

**Added**
- Maximum of (lazy) response(s) to be resolved when calling `Session.gather(..., max_fetch = ...)`. Specifying a valid int to `max_fetch` will stop after resolving the right amount of responses.

**Changed**
- urllib3.future minimal version raised to 2.3.900 to leverage the fallback top-level package `urllib3_future`.

**Fixed**
- Runtime error when accidentally overriding `urllib3.future` by an external dependency.
- Undesirable warning yielded by `cryptography` because of a Microsoft root certificate. "Parsed a negative serial number, which is disallowed by RFC 5280."
- Consider newly registered custom CA when using `wassima.register_ca(...)`.

**Removed**
- Dependency check at runtime for `urllib3`. There are no more checks and warnings at runtime for that subject. Ever.