### PR TITLE
refactoring prepare method and mypy error

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -241,11 +241,11 @@ class Request:
         except ValueError:
             return False
 
-    def create_prepared_request(self) -> PreparedRequest:
-        return PreparedRequest()
+    def prepare(self) -> PreparedRequest:
+        """Constructs a :class:`PreparedRequest <PreparedRequest>` for transmission and returns it."""
+        p = PreparedRequest()
 
-    def configure_prepared_request(self, prepared_request: PreparedRequest):
-        prepared_request.prepare(
+        p.prepare(
             method=self.method,
             url=self.url,
             headers=self.headers,
@@ -258,10 +258,7 @@ class Request:
             hooks=self.hooks,
         )
 
-    def prepare(self) -> PreparedRequest:
-        prepared_request = self.create_prepared_request()
-        self.configure_prepared_request(prepared_request)
-        return prepared_request
+        return p
 
 
 class PreparedRequest:

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -241,10 +241,11 @@ class Request:
         except ValueError:
             return False
 
-    def prepare(self) -> PreparedRequest:
-        """Constructs a :class:`PreparedRequest <PreparedRequest>` for transmission and returns it."""
-        p = PreparedRequest()
-        p.prepare(
+    def create_prepared_request(self) -> PreparedRequest:
+        return PreparedRequest()
+
+    def configure_prepared_request(self, prepared_request: PreparedRequest):
+        prepared_request.prepare(
             method=self.method,
             url=self.url,
             headers=self.headers,
@@ -256,7 +257,11 @@ class Request:
             cookies=self.cookies,
             hooks=self.hooks,
         )
-        return p
+
+    def prepare(self) -> PreparedRequest:
+        prepared_request = self.create_prepared_request()
+        self.configure_prepared_request(prepared_request)
+        return prepared_request
 
 
 class PreparedRequest:

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -31,6 +31,7 @@ from urllib.request import (  # type: ignore[attr-defined]
     proxy_bypass,
     proxy_bypass_environment,
 )
+from netrc import NetrcParseError, netrc
 
 from ._compat import HAS_LEGACY_URLLIB3
 
@@ -186,9 +187,6 @@ def get_netrc_auth(
 ) -> tuple[str, str] | None:
     """Returns the Requests tuple auth for a given url from netrc."""
 
-    from netrc import NetrcParseError
-    from netrc import netrc
-
     if url is None:
         return None
 
@@ -213,14 +211,16 @@ def get_netrc_auth(
 
         ri = urlparse(url)
         host = ri.hostname
+
         if host is None:
             return None
 
         _netrc = netrc(netrc_path).authenticators(host)
+
         if _netrc:
             login, _, password = _netrc
             if login and password:
-                return (login, password)
+                return login, password
             return None
     except NetrcParseError as e:
         if raise_errors:

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -183,7 +183,7 @@ def super_len(o: typing.Any) -> int:
 @lru_cache(maxsize=64)
 def get_netrc_auth(
     url: str | None, raise_errors: bool = False
-) -> tuple[str | bytes, str | bytes] | None:
+) -> tuple[str, str] | None:
     """Returns the Requests tuple auth for a given url from netrc."""
 
     from netrc import NetrcParseError, netrc
@@ -211,18 +211,18 @@ def get_netrc_auth(
             return None
 
         ri = urlparse(url)
-        host = ri.netloc.split(":")[0]
+        host = ri.hostname
 
         _netrc = netrc(netrc_path).authenticators(host)
         if _netrc:
-            login = _netrc[0] if isinstance(_netrc[0], bytes) else _netrc[0].encode()
-            password = _netrc[2].encode() if isinstance(_netrc[2], str) else _netrc[2]
-            password = password if password is not None else b""
+            login = _netrc[0]
+            password = _netrc[2]
+            password = password if password is not None else ""
             return (login, password)
     except (NetrcParseError, OSError):
         if raise_errors:
             raise
-    except (ImportError, AttributeError):
+    except AttributeError:
         pass
 
     return None

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -230,12 +230,11 @@ def get_netrc_auth(
         try:
             _netrc = netrc(netrc_path).authenticators(host)
             if _netrc:
-                # Return with login / password
-                login_i = 0 if _netrc[0] else 1
-                return (_netrc[login_i], _netrc[2])
+                # Assurez-vous que login et password ne sont pas None
+                login = _netrc[0] if _netrc[0] else ""
+                password = _netrc[2] if _netrc[2] else ""
+                return (login, password)
         except (NetrcParseError, OSError):
-            # If there was a parsing error or a permissions issue reading the file,
-            # we'll just skip netrc auth unless explicitly asked to raise errors.
             if raise_errors:
                 raise
 


### PR DESCRIPTION
Refactoring Suggestions
Separation of Responsibilities: The prepare method currently does two things: it creates a new PreparedRequest object and configures it. To improve clarity, these two responsibilities could be separated into two distinct methods.

Creation Method: You could have a separate method for creating the PreparedRequest object, which would make the code more modular and reusable.

Configuration Method: Another method could be dedicated to configuring this PreparedRequest object. This method would take a PreparedRequest object as a parameter and apply all the necessary configurations.

Error when launching mypy: src/niquests/utils.py:235: error: Incompatible return value type (got "tuple[str | None, str | None]", expected "tuple[str, str] | None")  [return-value]
Suggested correction by modifying the get_netrc_auth function.