### PR TITLE
:bookmark: Release 3.4.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+3.4.1 (2024-01-07)
+------------------
+
+**Fixed**
+- CaseInsensibleDict did not properly convert HTTPHeaderDict from urllib3 thus only letting the last entry in.
+- Redirect chain lead to a non waited coroutine in `AsyncSession`.
+
 3.4.0 (2024-01-01)
 ------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
-__build__: int = 0x030400
+__build__: int = 0x030401
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1518,16 +1518,28 @@ class Session:
             else:
                 if yield_requests_trail:
                     yield req
-                resp = self.send(
-                    req,
-                    stream=stream,
-                    timeout=timeout,
-                    verify=verify,
-                    cert=cert,
-                    proxies=proxies,
-                    allow_redirects=False,
-                    **adapter_kwargs,
-                )
+                if "AsyncSession" not in str(type(self)):
+                    resp = self.send(
+                        req,
+                        stream=stream,
+                        timeout=timeout,
+                        verify=verify,
+                        cert=cert,
+                        proxies=proxies,
+                        allow_redirects=False,
+                        **adapter_kwargs,
+                    )
+                else:
+                    resp = super(self.__class__, self).send(  # type: ignore[misc]
+                        req,
+                        stream=stream,
+                        timeout=timeout,
+                        verify=verify,
+                        cert=cert,
+                        proxies=proxies,
+                        allow_redirects=False,
+                        **adapter_kwargs,
+                    )
 
                 extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 

--- a/src/niquests/structures.py
+++ b/src/niquests/structures.py
@@ -68,6 +68,9 @@ class CaseInsensitiveDict(MutableMapping):
         ] = OrderedDict()
         if data is None:
             data = {}
+        fmt_data = str(type(data))
+        if "urllib3" in fmt_data and "HTTPHeaderDict" in fmt_data:
+            data = dict(data)
         normalized_items = []
         for k, v in data.items() if hasattr(data, "items") else data:
             normalized_items.append(_ensure_str_or_bytes(k, v))

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -17,6 +17,13 @@ class TestAsyncWithoutMultiplex:
             assert resp.lazy is False
             assert resp.status_code == 200
 
+    async def test_awaitable_redirect_chain(self):
+        async with AsyncSession() as s:
+            resp = await s.get("https://pie.dev/redirect/2")
+
+            assert resp.lazy is False
+            assert resp.status_code == 200
+
     async def test_concurrent_task_get(self):
         async def emit():
             responses = []

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from niquests.structures import CaseInsensitiveDict, LookupDict
+from urllib3 import HTTPHeaderDict
 
 
 class TestCaseInsensitiveDict:
@@ -51,6 +52,16 @@ class TestCaseInsensitiveDict:
     )
     def test_instance_equality(self, other, result):
         assert (self.case_insensitive_dict == other) is result
+
+    def test_lossless_convert_into_mono_entry(self):
+        o = HTTPHeaderDict()
+        o.add("Hello", "1")
+        o.add("Hello", "2")
+        o.add("Hello", "3")
+
+        u = CaseInsensitiveDict(o)
+
+        assert u["Hello"] == "1, 2, 3"
 
 
 class TestLookupDict:


### PR DESCRIPTION
**Fixed**

- CaseInsensibleDict did not properly convert HTTPHeaderDict from urllib3 thus only letting the last entry in.
- Redirect chain lead to a non waited coroutine in `AsyncSession`.