### PR TITLE
:bookmark: Release 3.4.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,18 @@
 Release History
 ===============
 
+3.4.3 (2024-01-16)
+------------------
+
+**Fixed**
+- Accessing a lazy response (multiplexed enabled) that have multiple redirects did not work appropriately.
+
+**Changed**
+- Response `iter_content` and `iter_line` read chunks as they arrive by default. The default chunk size is now `-1`.
+  `-1` mean to instruct that the chunks can be of variable sizes, depending on how packets arrives. It improves
+  overall performances.
+- urllib3.future lower bound constraint has been raised to version 2.4.904 in order to accept `-1` as a chunk size.
+
 3.4.2 (2024-01-11)
 ------------------
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -352,7 +352,7 @@ urllib3 :class:`urllib3.HTTPResponse <urllib3.response.HTTPResponse>` at
 :attr:`Response.raw <niquests.Response.raw>`.
 
 If you set ``stream`` to ``True`` when making a request, Niquests cannot
-release the connection back to the pool unless you consume all the data or call
+release the connection back to the pool unless you consume all the data (HTTP/1.1 only) or call
 :meth:`Response.close <niquests.Response.close>`. This can lead to
 inefficiency with connections. If you find yourself partially reading request
 bodies (or not reading them at all) while using ``stream=True``, you should
@@ -1358,10 +1358,14 @@ Setting the source network adapter
 In a complex scenario, you could face the following: "I have multiple network adapters, some can access this and other that.."
 Since Niquests 3.4+, you can configure that aspect per ``Session`` instance.
 
-Having a session without IPv6 enabled should be done that way::
+Having a session that explicitly bind to "10.10.4.1" on port 4444 should be done that way::
 
     import niquests
 
-    session = niquests.Session(source_address=(10.10.4.1, 4444))
+    session = niquests.Session(source_address=("10.10.4.1", 4444))
 
 It will be passed down the the lower stack. No effort required.
+
+.. note:: You can set **0** instead of 4444 to select a random port.
+
+.. note:: You can set **0.0.0.0** to select the network adapter automatically instead, if you wish to set the port only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,17 +41,17 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.4.901,<3",
+    "urllib3.future>=2.4.904,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
 
 [project.optional-dependencies]
 socks = [
-    "urllib3.future[socks]>=2.4.901,<3",
+    "urllib3.future[socks]",
 ]
 http3 = [
-    "urllib3.future[qh3]>=2.4.901,<3"
+    "urllib3.future[qh3]"
 ]
 ocsp = [
     "cryptography<42.0.0,>=41.0.0"

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 
-__build__: int = 0x030402
+__build__: int = 0x030403
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -724,7 +724,7 @@ class AsyncResponse(Response):
         return self
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        async for chunk in await self.iter_content(128):
+        async for chunk in await self.iter_content(ITER_CHUNK_SIZE):
             yield chunk
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -743,7 +743,7 @@ class AsyncResponse(Response):
         ...
 
     async def iter_content(  # type: ignore[override]
-        self, chunk_size: int = 1, decode_unicode: bool = False
+        self, chunk_size: int = ITER_CHUNK_SIZE, decode_unicode: bool = False
     ) -> typing.AsyncGenerator[bytes | str, None]:
         async def generate() -> (
             typing.AsyncGenerator[

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1133,7 +1133,6 @@ class Session:
 
         # We are leveraging a multiplexed connection
         if r.raw is None:
-            r._gather = lambda: adapter.gather(r)
             r._resolve_redirect = lambda x, y: next(
                 self.resolve_redirects(x, y, yield_requests=True, **kwargs),  # type: ignore
                 None,

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -56,7 +56,21 @@ class TestAsyncWithMultiplex:
 
             assert resp.lazy is True
             await s.gather()
+            assert resp.status_code == 200
 
+    async def test_awaitable_redirect_with_lazy(self):
+        async with AsyncSession(multiplexed=True) as s:
+            resp = await s.get("https://pie.dev/redirect/3")
+
+            assert resp.lazy is True
+            await s.gather()
+            assert resp.status_code == 200
+
+    async def test_awaitable_redirect_direct_access_with_lazy(self):
+        async with AsyncSession(multiplexed=True) as s:
+            resp = await s.get("https://pie.dev/redirect/3")
+
+            assert resp.lazy is True
             assert resp.status_code == 200
 
     async def test_awaitable_get_direct_access_lazy(self):


### PR DESCRIPTION
**Fixed**
- Accessing a lazy response (multiplexed enabled) that have multiple redirects did not work appropriately.

**Changed**
- Response `iter_content` and `iter_line` read chunks as they arrive by default. The default chunk size is now `-1`. `-1` mean to instruct that the chunks can be of variable sizes, depending on how packets arrives. It improves overall performances.
- urllib3.future lower bound constraint has been raised to version 2.4.904 in order to accept `-1` as a chunk size.