### PR TITLE
:bug: Fix redirect within a multiplexed Session when first response is HTTP/1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+3.4.4 (2024-01-18)
+------------------
+
+**Fixed**
+- Issuing a request with `Session(multiplexed=True)` that weren't eligible (e.g. HTTP/1.1) but was redirected to an
+  eligible server (HTTP/2+) caused a rare error.
+
 3.4.3 (2024-01-16)
 ------------------
 

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1544,6 +1544,12 @@ class Session:
                         **adapter_kwargs,
                     )
 
+                # If the initial request was intended to be lazy but didn't meet required criteria
+                # e.g. Setting multiplexed=True, requesting HTTP/1.1 only capable and getting redirected
+                # to an HTTP/2+ endpoint.
+                if resp.lazy:
+                    resp.status_code
+
                 extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 
                 # extract redirect url, if any, for the next loop


### PR DESCRIPTION
Issuing a request with `Session(multiplexed=True)` that weren't eligible (e.g. HTTP/1.1) but was redirected to an
eligible server (HTTP/2+) caused a rare error.