### PR TITLE
:bookmark: Release 3.4.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,20 @@
 Release History
 ===============
 
+3.4.5 (2024-02-02)
+------------------
+
+**Fixed**
+- Thread-safety issue when leveraging a single multiplexed connection across multiple threads.
+- Apparently consumed content when allow_redirect is set to True when accessing a lazy response that follow redirects.
+
+**Changed**
+- urllib3.future lower bound constraint has been raised to version 2.5.900 in order to leverage the advanced multiplexing scheduler.
+  This upgrade come with a noticeable performance bump.
+
+**Added**
+- ``Session`` constructor now accepts both ``pool_connections`` and ``pool_maxsize`` parameters to scale your pools of connections at will.
+
 3.4.4 (2024-01-18)
 ------------------
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -694,8 +694,6 @@ Any ``Response`` returned by get, post, put, etc... will be a lazy instance of `
 
 The possible algorithms are actually nearly limitless, and you may arrange/write you own scheduling technics!
 
-.. warning:: Beware that all in-flight (unresolved) lazy responses are lost immediately after closing the ``Session``. Trying to access unresolved and lost responses will result in ``MultiplexingError`` exception being raised.
-
 Session Gather
 --------------
 
@@ -871,6 +869,23 @@ Here is a basic example of how you would do it::
         asyncio.run(main())
 
 .. warning:: Accessing a lazy ``AsyncResponse`` without a call to ``s.gather()`` will raise a warning.
+
+Scale your Session / Pool
+-------------------------
+
+By default, Niquests allow, concurrently 10 hosts, and 10 connections per host.
+You can at your own discretion increase or decrease the values.
+
+To do so, you are invited to set the following parameters within a Session constructor:
+
+``Session(pool_connections=10, pool_maxsize=10)``
+
+- **pool_connections** means the number of host target (or pool of connections if you prefer).
+- **pool_maxsize** means the maximum of concurrent connexion per host target/pool.
+
+.. warning:: Due to the multiplexed aspect of both HTTP/2, and HTTP/3 you can issue, usually, more than 200 requests per connection without ever needing to create another one.
+
+.. note:: This setting is most useful for multi-threading application.
 
 DNS Resolution
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "niquests"
-description = "Python HTTP for Humans."
+description = "Niquests is a simple, yet elegant, HTTP library. It is a drop-in replacement for Requests, which is under feature freeze."
 readme = "README.md"
 license-files = { paths = ["LICENSE"] }
 license = "Apache-2.0"
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.4.904,<3",
+    "urllib3.future>=2.5.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
@@ -54,7 +54,7 @@ http3 = [
     "urllib3.future[qh3]"
 ]
 ocsp = [
-    "cryptography<42.0.0,>=41.0.0"
+    "cryptography<43.0.0,>=41.0.0"
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .[socks]
-pytest>=2.8.0,<=7.4.2
+pytest>=2.8.0,<=7.4.4
 pytest-cov
 pytest-httpbin==2.0.0
 pytest-asyncio>=0.21.1,<1.0

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.4.4"
+__version__ = "3.4.5"
 
-__build__: int = 0x030404
+__build__: int = 0x030405
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -753,6 +753,8 @@ class HTTPAdapter(BaseAdapter):
                 multiplexed=multiplexed,
             )
 
+            if hasattr(self.poolmanager.pools, "memorize"):
+                self.poolmanager.pools.memorize(resp_or_promise, conn)
         except (ProtocolError, OSError) as err:
             if "illegal header" in str(err).lower():
                 raise InvalidHeader(err, request=request)
@@ -935,6 +937,9 @@ class HTTPAdapter(BaseAdapter):
 
             origin_response.history.pop()
 
+            origin_response._content = False
+            origin_response._content_consumed = False
+
             origin_response.status_code, leaf_response.status_code = (
                 leaf_response.status_code,
                 origin_response.status_code,
@@ -1053,7 +1058,7 @@ class HTTPAdapter(BaseAdapter):
 
                     next_resp = self._future_handler(response, low_resp)
 
-                    if next_resp:
+                    if next_resp is not None:
                         still_redirects.append(next_resp)
 
                 if still_redirects:

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -27,7 +27,12 @@ if HAS_LEGACY_URLLIB3 is False:
 else:
     from urllib3_future import ConnectionInfo  # type: ignore[assignment]
 
-from ._constant import DEFAULT_RETRIES, READ_DEFAULT_TIMEOUT, WRITE_DEFAULT_TIMEOUT
+from ._constant import (
+    DEFAULT_RETRIES,
+    READ_DEFAULT_TIMEOUT,
+    WRITE_DEFAULT_TIMEOUT,
+    DEFAULT_POOLSIZE,
+)
 from ._typing import (
     BodyType,
     CacheLayerAltSvcType,
@@ -212,6 +217,8 @@ class Session:
         "_disable_ipv6",
         "_disable_http2",
         "_disable_http3",
+        "_pool_connections",
+        "_pool_maxsize",
     ]
 
     def __init__(
@@ -226,7 +233,22 @@ class Session:
         disable_http3: bool = False,
         disable_ipv6: bool = False,
         disable_ipv4: bool = False,
+        pool_connections: int = DEFAULT_POOLSIZE,
+        pool_maxsize: int = DEFAULT_POOLSIZE,
     ):
+        """
+        :param resolver: Specify a DNS resolver that should be used within this Session.
+        :param source_address: Bind Session to a specific network adapter and/or port so that all outgoing requests.
+        :param quic_cache_layer: Provide an external cache mechanism to store HTTP/3 host capabilities.
+        :param retries: Configure a number of times a request must be automatically retried before giving up.
+        :param multiplexed: Enable or disable concurrent request when the remote host support HTTP/2 onward.
+        :param disable_http2: Toggle to disable negotiating HTTP/2 with remote peers.
+        :param disable_http3: Toggle to disable negotiating HTTP/3 with remote peers.
+        :param disable_ipv6: Toggle to disable using IPv6 even if the remote host supports IPv6.
+        :param disable_ipv4: Toggle to disable using IPv4 even if the remote host supports IPv4.
+        :param pool_connections: Number of concurrent hosts to be handled by this Session at a maximum.
+        :param pool_maxsize: Maximum number of concurrent connections per (single) host at a time.
+        """
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
 
@@ -283,6 +305,9 @@ class Session:
         self._disable_ipv4 = disable_ipv4
         self._disable_ipv6 = disable_ipv6
 
+        self._pool_connections = pool_connections
+        self._pool_maxsize = pool_maxsize
+
         #: SSL Verification default.
         #: Defaults to `True`, requiring requests to verify the TLS certificate at the
         #: remote end.
@@ -335,6 +360,8 @@ class Session:
                 source_address=source_address,
                 disable_ipv4=disable_ipv4,
                 disable_ipv6=disable_ipv6,
+                pool_connections=pool_connections,
+                pool_maxsize=pool_maxsize,
             ),
         )
         self.mount(
@@ -345,6 +372,8 @@ class Session:
                 source_address=source_address,
                 disable_ipv4=disable_ipv4,
                 disable_ipv6=disable_ipv6,
+                pool_connections=pool_connections,
+                pool_maxsize=pool_maxsize,
             ),
         )
 
@@ -1106,6 +1135,8 @@ class Session:
                     source_address=self.source_address,
                     disable_ipv4=self._disable_ipv4,
                     disable_ipv6=self._disable_ipv6,
+                    pool_connections=self._pool_connections,
+                    pool_maxsize=self._pool_maxsize,
                 ),
             )
             self.mount(
@@ -1116,6 +1147,8 @@ class Session:
                     source_address=self.source_address,
                     disable_ipv4=self._disable_ipv4,
                     disable_ipv6=self._disable_ipv6,
+                    pool_connections=self._pool_connections,
+                    pool_maxsize=self._pool_maxsize,
                 ),
             )
 
@@ -1315,6 +1348,8 @@ class Session:
                 disable_ipv4=self._disable_ipv4,
                 disable_ipv6=self._disable_ipv6,
                 resolver=self.resolver,
+                pool_connections=self._pool_connections,
+                pool_maxsize=self._pool_maxsize,
             ),
         )
         self.mount(
@@ -1325,6 +1360,8 @@ class Session:
                 disable_ipv4=self._disable_ipv4,
                 disable_ipv6=self._disable_ipv6,
                 resolver=self.resolver,
+                pool_connections=self._pool_connections,
+                pool_maxsize=self._pool_maxsize,
             ),
         )
 


### PR DESCRIPTION
**Fixed**
- Thread-safety issue when leveraging a single multiplexed connection across multiple threads.
- Apparently consumed content when allow_redirect is set to True when accessing a lazy response that follow redirects.

**Changed**
- urllib3.future lower bound constraint has been raised to version 2.5.900 in order to leverage the advanced multiplexing scheduler. This upgrade come with a noticeable performance bump in a complex multiplexed context.

**Added**
- ``Session`` constructor now accepts both ``pool_connections`` and ``pool_maxsize`` parameters to scale your pools of connections at will.