### PR TITLE
:bookmark: Release 3.4.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,11 +1,14 @@
 Release History
 ===============
 
-3.4.6 (2024-02-03)
+3.4.6 (2024-02-21)
 ------------------
 
 **Fixed**
 - Unmatched filter for deprecation warning yielded by Cryptography due to some legacy CA available in Windows having a negative serial number.
+- Setting `boundary` in `Content-Type` header with no value associated (no equal sign) can cause a rare error (multipart).
+- Rare racing condition while emitting too many request across a multiplexed connections.
+- Spawning too many threads while using `AsyncSession` in specific contexts.
 
 3.4.5 (2024-02-02)
 ------------------

--- a/docs/dev/migrate.rst
+++ b/docs/dev/migrate.rst
@@ -1,0 +1,67 @@
+.. _migrate:
+
+Migration Guide
+================
+
+If you're reading this, you're probably interested in Niquests. We're thrilled to have
+you onboard.
+
+This section will cover two use cases:
+
+- I am a developer that regularly drive Requests
+- I am a library maintainer that depend on Requests
+
+Developer migration
+-------------------
+
+Niquests aims to be as compatible as possible with Requests, and that is
+with confidence that you can migrate to Niquests without breaking changes.
+
+.. code-block::python
+    import requests
+
+    requests.get(...)
+
+Would turn into either
+
+.. code-block::python
+    import niquests
+
+    niquests.get(...)
+
+Or simply
+
+.. code-block::python
+    import niquests as requests
+
+    requests.get(...)
+
+
+Maintainer migration
+-------------------
+
+In order to migrate your library with confidence, you'll have to also adjust your tests.
+The library itself (sources) should be really easy to migrate (cf. developer migration)
+but the tests may be harder to adapt.
+
+The main reason behind this difficulty is often related to a strong tie with third-party
+mocking library such as ``response``.
+
+To overcome this, we will introduce you to a clever bypass. If you are using pytest, do the
+following in your ``conftest.py``, see https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
+for more information. (The goal would simply to execute the following piece of code before the tests)
+
+.. code-block::python
+    from sys import modules
+
+    import niquests
+    import urllib3
+
+    # the mock utility 'response' only works with 'requests'
+    modules["requests"] = niquests
+    modules["requests.adapters"] = niquests.adapters
+    modules["requests.exceptions"] = niquests.exceptions
+    modules["requests.packages.urllib3"] = urllib3
+
+.. warning:: This code sample is only to be executed in a development environment, it permit to fool the third-party dependencies that have a strong tie on Requests.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,6 +118,7 @@ Niquests ecosystem and community.
 .. toctree::
    :maxdepth: 2
 
+   dev/migrate
    community/recommended
    community/faq
    community/support

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -726,7 +726,7 @@ Here is a basic example::
     from niquests import AsyncSession, Response
 
     async def fetch(url: str) -> Response:
-        with AsyncSession() as s:
+        async with AsyncSession() as s:
             return await s.get(url)
 
     async def main() -> None:
@@ -762,7 +762,7 @@ Look at this basic sample::
     async def fetch(url: str) -> list[Response]:
         responses = []
 
-        with AsyncSession(multiplexed=True) as s:
+        async with AsyncSession(multiplexed=True) as s:
             for _ in range(10):
                 responses.append(await s.get(url))
 

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -544,9 +544,10 @@ class PreparedRequest:
 
                     if enforce_form_data:
                         form_data_boundary = (
-                            self.oheaders.content_type.boundary  # type: ignore[union-attr]
+                            self.oheaders.content_type.get("boundary")  # type: ignore[union-attr]
                             if enforce_form_data
-                            and self.oheaders.content_type.has("boundary")  # type: ignore[union-attr]
+                            and self.oheaders.content_type.has_many("boundary") is False  # type: ignore[union-attr]
+                            and self.oheaders.content_type.get("boundary") is not None  # type: ignore[union-attr]
                             else choose_boundary()
                         )
                     else:
@@ -554,7 +555,7 @@ class PreparedRequest:
 
                     body = self._encode_params(
                         data,  # type: ignore[arg-type]
-                        boundary_for_multipart=form_data_boundary,
+                        boundary_for_multipart=form_data_boundary,  # type: ignore[arg-type]
                     )
                     if isinstance(data, str) or hasattr(data, "read"):
                         content_type = None


### PR DESCRIPTION
3.4.6 (2024-02-21)
------------------

**Fixed**
- Unmatched filter for deprecation warning yielded by Cryptography due to some legacy CA available in Windows having a negative serial number.
- Setting `boundary` in `Content-Type` header with no value associated (no equal sign) can cause a rare error (multipart).
- Rare racing condition while emitting too many request across a multiplexed connections.
- Spawning too many threads while using `AsyncSession` in specific contexts.