### PR TITLE
:zap: Fix unintentional performance regression with multiple concurrent multiplexed connection within a single Session

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.4.7 (2024-02-21)
+------------------
+
+**Fixed**
+- Unintentional performance regression with multiple concurrent multiplexed connection within a single Session.
+
 3.4.6 (2024-02-21)
 ------------------
 

--- a/docs/dev/migrate.rst
+++ b/docs/dev/migrate.rst
@@ -17,21 +17,21 @@ Developer migration
 Niquests aims to be as compatible as possible with Requests, and that is
 with confidence that you can migrate to Niquests without breaking changes.
 
-.. code-block::python
+.. code-block:: python
     import requests
 
     requests.get(...)
 
 Would turn into either
 
-.. code-block::python
+.. code-block:: python
     import niquests
 
     niquests.get(...)
 
 Or simply
 
-.. code-block::python
+.. code-block:: python
     import niquests as requests
 
     requests.get(...)
@@ -51,7 +51,7 @@ To overcome this, we will introduce you to a clever bypass. If you are using pyt
 following in your ``conftest.py``, see https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
 for more information. (The goal would simply to execute the following piece of code before the tests)
 
-.. code-block::python
+.. code-block:: python
     from sys import modules
 
     import niquests

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.4.6"
+__version__ = "3.4.7"
 
-__build__: int = 0x030406
+__build__: int = 0x030407
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"


### PR DESCRIPTION
was due to an abusive lock.