### PR TITLE
:bookmark: Release 3.5.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,4 +83,4 @@ jobs:
         gh release upload ${{ github.ref_name }} dist/* --repo ${{ github.repository }}
 
     - name: "Publish dists to PyPI"
-      uses: "pypa/gh-action-pypi-publish@f8c70e705ffc13c3b4d1221169b84f12a75d6ca8" # v1.8.8
+      uses: "pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450" # v1.8.14

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,13 +9,13 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.10.1
+  rev: v3.15.1
   hooks:
     - id: pyupgrade
       args: [--py37-plus]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.7
+  rev: v0.3.2
   hooks:
     # Run the linter.
     - id: ruff
@@ -23,7 +23,7 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.5.1
+  rev: v1.9.0
   hooks:
   -   id: mypy
       args: [--check-untyped-defs]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,23 @@
 Release History
 ===============
 
+3.5.4 (2024-03-17)
+------------------
+
+**Added**
+- Support to verify the peer certificate fingerprint using `verify=...` by passing a string using the following format:
+  `verify="sha256_748c76348778cb4a536e7ec12bc9aa559c12770bd1419c7ffe516006e1dea0ec"`. Doing so disable the certificate
+  usual verification and only checks for its fingerprint match.
+
+**Fixed**
+- Multiplexed request in async did not support awaitable in hooks.
+- Setting `verify=...` and `cert=...` then change it for the same host did not apply to the underlying (existing) connection pool.
+
+**Misc**
+- Overall performance improvements in both async and sync requests.
+- Update pre-commit dependencies (ruff, pyupgrade, and mypy).
+- Fixed SessionRedirect in tests that produced an incomplete Response instance that wasn't suitable for tests.
+
 3.5.3 (2024-03-06)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -40,28 +40,33 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 </details>
 
 <details>
-  <summary>📈 <b>Look at the performance comparison</b> against <i>requests, httpx and aiohttp</i>!</summary>
+  <summary>📈 <b>Look at the performance comparison</b> against <i>them</i>!</summary>
 
 _Scenario:_ Fetch a thousand requests using 10 tasks or threads, each with a hundred requests using a single pool of connection.
 
 **High-Level APIs**
 
-| Client   | Average Delay to Complete | Notes                        |
-|----------|---------------------------|------------------------------|
-| requests | 987 ms                    | ThreadPoolExecutor. HTTP/1.1 |
-| httpx    | 735 ms                    | Asyncio. HTTP/2              |
-| niquests | 600 ms                    | Asyncio. HTTP/2              |
+| Client   | Average Delay to Complete                | Notes                        |
+|----------|------------------------------------------|------------------------------|
+| requests | <span style="color:red">987 ms</span>    | ThreadPoolExecutor. HTTP/1.1 |
+| httpx    | <span style="color:orange">735 ms</span> | Asyncio. HTTP/2              |
+| niquests | <span style="color:green">470 ms</span>  | Asyncio. HTTP/2              |
 
 **Simplified APIs**
 
-| Client        | Average Delay to Complete | Notes                        |
-|---------------|---------------------------|------------------------------|
-| requests core | 643 ms                    | ThreadPoolExecutor. HTTP/1.1 |
-| httpx core    | 550 ms                    | Asyncio. HTTP/2              |
-| aiohttp       | 220 ms                    | Asyncio. HTTP/1.1            |
-| niquests core | 210 ms                    | Asyncio. HTTP/2              |
+| Client        | Average Delay to Complete                | Notes                        |
+|---------------|------------------------------------------|------------------------------|
+| requests core | <span style="color:red">643 ms</span>    | ThreadPoolExecutor. HTTP/1.1 |
+| httpx core    | <span style="color:orange">550 ms</span> | Asyncio. HTTP/2              |
+| aiohttp       | <span style="color:green">220 ms</span>  | Asyncio. HTTP/1.1            |
+| niquests core | <span style="color:green">210 ms</span>  | Asyncio. HTTP/2              |
 
-Want to learn more about the tests? scripts? reasoning? Take a deeper look at https://github.com/Ousret/niquests-stats
+Did you give up on HTTP/2 due to performance concerns? Think again! Multiplexing and response lazyness open up a wide range
+of possibilities! Want to learn more about the tests? scripts? reasoning?
+
+Take a deeper look at https://github.com/Ousret/niquests-stats
+
+⚠️ Do the responsible thing with this library and do not attempt DoS remote servers using its abilities.
 </details>
 
 ```python
@@ -169,7 +174,7 @@ purchasing and maintaining their software, with professional grade assurances
 from the experts who know it best, while seamlessly integrating with existing
 tools.
 
-You may also be interested in unlocking specific advantages by looking at our [GitHub sponsor tiers](https://github.com/sponsors/Ousret).
+You may also be interested in unlocking specific advantages _(like access to a private issue tracker)_ by looking at our [GitHub sponsor tiers](https://github.com/sponsors/Ousret).
 
 ---
 
@@ -179,7 +184,7 @@ Niquests is a highly improved HTTP client that is based (forked) on Requests. Th
 [^2]: requests has no support for asynchronous request.
 [^3]: while the HTTP/2 connection object can handle concurrent requests, you cannot leverage its true potential.
 [^4]: loading client certificate without file can't be done.
-[^5]: httpx officially claim to be thread safe but recent tests demonstrate otherwise as of february 2024.
+[^5]: httpx officially claim to be thread safe but recent tests demonstrate otherwise as of february 2024. https://github.com/jawah/niquests/issues/83#issuecomment-1956065258 https://github.com/encode/httpx/issues/3072 https://github.com/encode/httpx/issues/3002
 [^6]: they do not expose anything to control network aspects such as IPv4/IPv6 toggles, and timings (e.g. DNS response time, established delay, TLS handshake delay, etc...) and such.
 [^7]: while advertised as possible, they refuse to make it the default due to performance issues. as of february 2024 an extra is required to enable it manually.
 [^8]: they don't support HTTP/3 at all.

--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -36,3 +36,26 @@ to provide authentication. It also provides a lot of tweaks that handle ways
 that specific OAuth providers differ from the standard specifications.
 
 .. _requests-oauthlib: https://requests-oauthlib.readthedocs.io/en/latest/
+
+.. warning:: There's a catch when trying to use Niquests with `requests-oauthlib`_. You will need a quick patch prior to using it.
+
+Please patch your program as follow::
+
+    import niquests
+    from oauthlib.oauth2 import BackendApplicationClient
+    import requests_oauthlib
+
+    requests_oauthlib.OAuth2Session.__bases__ = (niquests.Session,)
+
+    client_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    token_url = 'https://api.github.com/token'
+
+    if __name__ == "__main__":
+        client = BackendApplicationClient(client_id=client_id)
+        sample = requests_oauthlib.OAuth2Session(client=client)
+
+        token = sample.fetch_token(token_url, client_secret=client_secret)
+
+The key element to be considered is ``requests_oauthlib.OAuth2Session.__bases__ = (niquests.Session,)``.
+You may apply it to `requests_oauthlib.OAuth1Session` too.

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1371,3 +1371,49 @@ It will be passed down the the lower stack. No effort required.
 .. note:: You can set **0** instead of 4444 to select a random port.
 
 .. note:: You can set **0.0.0.0** to select the network adapter automatically instead, if you wish to set the port only.
+
+Inspect network timings
+-----------------------
+
+You are probably used to calling ``response.elapsed`` to get a rough estimate on how long did the
+request took to complete.
+
+It is likely that you may be interested in knowing:
+
+- How long did the TCP/UDP established connection took?
+- How long did the DNS resolution cost me?
+
+... and so on.
+
+Here is a simple example::
+
+    import niquests
+
+    session = niquests.Session()
+
+    response = session.get("https://pie.dev/get")
+
+    print(response.conn_info.resolution_latency)  # output the DNS resolution latency
+    print(response.conn_info.tls_handshake_latency)  # the TLS handshake completion
+
+Here, ``conn_info`` is a ``urllib3.ConnectionInfo`` instance. The complete list of
+attributes is listed on the Hook bottom section.
+
+.. note:: Each response and request are linked to a unique ConnectionInfo.
+
+Verify Certificate Fingerprint
+------------------------------
+
+.. note:: Available since Niquests 3.5.4
+
+An alternative to the certificate verification can be asserting its fingerprint. We (absolutely) do
+not recommend using it unless you are left with no other alternative.
+
+Here is a simple example::
+
+    import niquests
+
+    session = niquests.Session()
+    session.get("https://pie.dev/get", verify="sha256_8fff956b66667ffe5801c8432b12c367254727782d91bc695b7a53d0b512d721")
+
+.. warning:: Supported fingerprinting algorithms are sha256, and sha1. The prefix is mandatory.

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.5.3"
+__version__ = "3.5.4"
 
-__build__: int = 0x030503
+__build__: int = 0x030504
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -7,6 +7,7 @@ This module implements the Requests API.
 :copyright: (c) 2012 by Kenneth Reitz.
 :license: Apache2, see LICENSE for more details.
 """
+
 from __future__ import annotations
 
 import typing

--- a/src/niquests/auth.py
+++ b/src/niquests/auth.py
@@ -4,6 +4,7 @@ requests.auth
 
 This module contains the authentication handlers for Requests.
 """
+
 from __future__ import annotations
 
 import hashlib

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -6,6 +6,7 @@ Compatibility code to be able to use `http.cookiejar.CookieJar` with requests.
 
 requests.utils imports from here, so be careful with imports.
 """
+
 from __future__ import annotations
 
 import calendar
@@ -20,6 +21,7 @@ from http.cookies import Morsel
 from urllib.parse import urlparse, urlunparse
 
 from ._compat import HAS_LEGACY_URLLIB3
+from .utils import parse_scheme
 
 if HAS_LEGACY_URLLIB3 is False:
     from urllib3 import BaseHTTPResponse
@@ -45,7 +47,11 @@ class MockRequest:
     def __init__(self, request):
         self._r = request
         self._new_headers = {}
-        self.type = urlparse(self._r.url).scheme
+
+        try:
+            self.type: str | None = parse_scheme(self._r.url)
+        except ValueError:
+            self.type = None
 
     def get_type(self):
         return self.type

--- a/src/niquests/exceptions.py
+++ b/src/niquests/exceptions.py
@@ -4,6 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
+
 from __future__ import annotations
 
 import typing

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -79,7 +79,7 @@ async def _ask_nicely_for_issuer(
         0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5,
     )
 
-    randelem = [b"\xAC", b"\xDC", b"\xFA", b"\xAF"]
+    randelem = [b"\xac", b"\xdc", b"\xfa", b"\xaf"]
     client_random = b"".join([randelem[randint(0, 3)] for e in range(32)])
     our_ecdh_privkey = randint(42, 98)
     our_ecdh_pubkey_x, our_ecdh_pubkey_y = multiply_num_on_ec_point(

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -110,7 +110,7 @@ def _ask_nicely_for_issuer(
         0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5,
     )
 
-    randelem = [b"\xAC", b"\xDC", b"\xFA", b"\xAF"]
+    randelem = [b"\xac", b"\xdc", b"\xfa", b"\xaf"]
     client_random = b"".join([randelem[randint(0, 3)] for e in range(32)])
     our_ecdh_privkey = randint(42, 98)
     our_ecdh_pubkey_x, our_ecdh_pubkey_y = multiply_num_on_ec_point(

--- a/src/niquests/extensions/_picotls.py
+++ b/src/niquests/extensions/_picotls.py
@@ -4,6 +4,7 @@ speak with a TLS 1.2+ server. The goal of this is to extract
 the certificate chain to be used for OCSP stapling / revocation.
 It's not meant to establish a secure connection. Never!
 """
+
 from __future__ import annotations
 
 import hmac

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -1,4 +1,5 @@
 """Module containing bug report helper(s)."""
+
 from __future__ import annotations
 
 import json

--- a/src/niquests/hooks.py
+++ b/src/niquests/hooks.py
@@ -16,6 +16,7 @@ Available hooks:
 ``response``:
     The response generated from a Request.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -73,9 +74,12 @@ async def async_dispatch_hook(
     if hooks is None:
         return hook_data
 
-    callables: list[
-        HookCallableType[_HV] | AsyncHookCallableType[_HV]
-    ] | HookCallableType[_HV] | AsyncHookCallableType[_HV] | None = hooks.get(key)
+    callables: (
+        list[HookCallableType[_HV] | AsyncHookCallableType[_HV]]
+        | HookCallableType[_HV]
+        | AsyncHookCallableType[_HV]
+        | None
+    ) = hooks.get(key)
 
     if callables:
         if callable(callables):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -84,8 +84,8 @@ class TestRequests:
         (
             (MissingSchema, "hiwpefhipowhefopw"),
             (InvalidSchema, "localhost:3128"),
-            (InvalidSchema, "localhost.localdomain:3128/"),
-            (InvalidSchema, "10.122.1.1:3128/"),
+            (MissingSchema, "localhost.localdomain:3128/"),
+            (MissingSchema, "10.122.1.1:3128/"),
             (InvalidURL, "http://"),
             (InvalidURL, "http://*example.com"),
             (InvalidURL, "http://.example.com"),
@@ -189,7 +189,7 @@ class TestRequests:
 
     def test_whitespaces_are_removed_from_url(self):
         # Test for issue #3696
-        request = niquests.Request("GET", " http://example.com").prepare()
+        request = niquests.Request("GET", " http://example.com/").prepare()
         assert request.url == "http://example.com/"
 
     @pytest.mark.parametrize("scheme", ("http://", "HTTP://", "hTTp://", "HttP://"))
@@ -2412,7 +2412,6 @@ class TestMorselToCookieExpires:
 
 
 class TestMorselToCookieMaxAge:
-
     """Tests for morsel_to_cookie when morsel contains max-age."""
 
     def test_max_age_valid_int(self):
@@ -2514,6 +2513,8 @@ class RedirectSession(Session):
     def build_response(self):
         request = self.calls[-1].args[0]
         r = niquests.Response()
+
+        r.url = request.url
 
         try:
             r.status_code = int(self.redirects.pop(0))
@@ -2654,7 +2655,7 @@ class TestPreparingURLs:
     @pytest.mark.parametrize(
         "url,expected",
         (
-            ("http://google.com", "http://google.com/"),
+            ("http://google.com/", "http://google.com/"),
             ("http://ジェーピーニック.jp", "http://xn--hckqz9bzb1cyrb.jp/"),
             ("http://xn--n3h.net/", "http://xn--n3h.net/"),
             ("http://ジェーピーニック.jp".encode(), "http://xn--hckqz9bzb1cyrb.jp/"),


### PR DESCRIPTION
3.5.4 (2024-03-17)
------------------

**Added**
- Support to verify the peer certificate fingerprint using `verify=...` by passing a string using the following format:
  `verify="sha256_748c76348778cb4a536e7ec12bc9aa559c12770bd1419c7ffe516006e1dea0ec"`. Doing so disable the certificate
  usual verification and only checks for its fingerprint match.

**Fixed**
- Multiplexed request in async did not support awaitable in hooks.
- Setting `verify=...` and `cert=...` then change it for the same host did not apply to the underlying (existing) connection pool.

**Misc**
- Overall performance improvements in both async and sync requests.
- Update pre-commit dependencies (ruff, pyupgrade, and mypy).
- Fixed SessionRedirect in tests that produced an incomplete Response instance that wasn't suitable for tests.
