### PR TITLE
:sparkle: Support for Happy Eyeballs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,20 @@
 Release History
 ===============
 
+3.5.5 (2024-03-25)
+------------------
+
+**Added**
+- Support for Happy Eyeballs. This feature is disabled by default, you must pass `happy_eyeballs=True` within your session
+  constructor or http adapter in order to leverage this.
+
+**Fixed**
+- Missed close implementation in AsyncSession causing the underlying poolmanager to remain open.
+- Additional OCSP requests (following a redirect) did not use specified custom DNS resolver.
+
+**Changed**
+- urllib3.future lower bound constraint has been raised to version 2.7.900 for the newly added happy eyeballs feature.
+
 3.5.4 (2024-03-17)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `DNS over HTTPS`                    |    ✅     |     ❌     |       ❌       | ❌             |
 | `DNS over QUIC`                     |    ✅     |     ❌     |       ❌       | ❌             |
 | `DNS over TLS`                      |    ✅     |     ❌     |       ❌       | ❌             |
+| `Multiple DNS Resolver`             |    ✅     |     ❌     |       ❌       | ❌             |
 | `Network Fine Tuning & Inspect`     |    ✅     |     ❌     | _Limited_[^6] | _Limited_[^6] |
 | `Certificate Revocation Protection` |    ✅     |     ❌     |       ❌       | ❌             |
 | `Session Persistence`               |    ✅     |     ✅     |       ✅       | ✅             |
@@ -36,6 +37,7 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `HTTP/HTTPS Proxies`                |    ✅     |     ✅     |       ✅       | ✅             |
 | `TLS-in-TLS Support`                |    ✅     |     ✅     |       ✅       | ✅             |
 | `Direct HTTP/3 Negotiation`         |  ✅[^9]   |  N/A[^8]  |    N/A[^8]    | N/A[^8]       |
+| `Happy Eyeballs`                    |    ✅     |     ❌     |       ❌       | ✅             |
 | `Package / SLSA Signed`             |    ✅     |     ❌     |       ❌       | ✅             |
 </details>
 
@@ -149,6 +151,7 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
 - DNSSEC!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,7 @@ Niquests is ready for today's web.
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
 - DNSSEC!

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -974,6 +974,44 @@ install Niquests with::
 
     $ python -m pip install niquests[speedups]
 
+
+Happy Eyeballs
+--------------
+
+.. note:: Available since version 3.5.5+
+
+Thanks to the underlying library (urllib3.future) we are able to serve the Happy Eyeballs feature, one toggle away.
+
+Happy Eyeballs (also called Fast Fallback) is an algorithm published by the IETF that makes dual-stack applications
+(those that understand both IPv4 and IPv6) more responsive to users by attempting to connect using both IPv4 and IPv6
+at the same time (preferring IPv6), thus minimizing common problems experienced by users with imperfect IPv6 connections or setups.
+
+The name “happy eyeballs” derives from the term “eyeball” to describe endpoints which represent human Internet end-users, as opposed to servers.
+
+To enable Happy Eyeballs in Niquests, do as follow::
+
+    import niquests
+
+    with niquests.Session(happy_eyeballs=True) as s:
+        ...
+
+Or.. in async::
+
+    import niquests
+
+    async with niquests.AsyncSession(happy_eyeballs=True) as s:
+        ...
+
+A mere ``happy_eyeballs=True`` is sufficient to leverage its potential.
+
+.. note:: In case a server yield multiple IPv4 addresses but no IPv6, this still applies. Meaning that Niquests will connect concurrently to presented addresses and determine what is the fastest endpoint.
+
+.. note:: Like urllib3.future, you can pass an integer to increase the default number of concurrent connection to be tested. See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#happy-eyeballs to learn more.
+
+OCSP requests (certificate revocation checks) will follow given ``happy_eyeballs=True`` parameter.
+
+.. warning:: This feature is disabled by default and we are actually planning to make it enabled as the default in a future major.
+
 -----------------------
 
 Ready for more? Check out the :ref:`advanced <advanced>` section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.6.900,<3",
+    "urllib3.future>=2.7.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.5.4"
+__version__ = "3.5.5"
 
-__build__: int = 0x030504
+__build__: int = 0x030505
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_compat.py
+++ b/src/niquests/_compat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 try:
-    from urllib3._version import __version__
+    from urllib3 import __version__
 
     HAS_LEGACY_URLLIB3: bool = int(__version__.split(".")[-1]) < 900
 except (ValueError, ImportError):

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -296,6 +296,7 @@ async def verify(
     timeout: float | int = 0.2,
     proxies: ProxyType | None = None,
     resolver: AsyncBaseResolver | None = None,
+    happy_eyeballs: bool | int = False,
 ) -> None:
     conn_info: ConnectionInfo | None = r.conn_info
 
@@ -366,7 +367,9 @@ async def verify(
 
         from .._async import AsyncSession
 
-        async with AsyncSession(resolver=resolver) as session:
+        async with AsyncSession(
+            resolver=resolver, happy_eyeballs=happy_eyeballs
+        ) as session:
             session.trust_env = False
             session.proxies = proxies
 

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -321,6 +321,7 @@ def verify(
     timeout: float | int = 0.2,
     proxies: ProxyType | None = None,
     resolver: BaseResolver | None = None,
+    happy_eyeballs: bool | int = False,
 ) -> None:
     conn_info: ConnectionInfo | None = r.conn_info
 
@@ -389,7 +390,7 @@ def verify(
 
     from ..sessions import Session
 
-    with Session(resolver=resolver) as session:
+    with Session(resolver=resolver, happy_eyeballs=happy_eyeballs) as session:
         session.trust_env = False
         session.proxies = proxies
 

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -636,14 +636,15 @@ class PreparedRequest:
                     "Unexpected non-callable authentication. Did you pass unsupported tuple to auth argument?"
                 )
 
-            # Allow auth to make its changes.
-            r = auth(self)
+            if not asyncio.iscoroutinefunction(auth.__call__):
+                # Allow auth to make its changes.
+                r = auth(self)
 
-            # Update self to reflect the auth changes.
-            self.__dict__.update(r.__dict__)
+                # Update self to reflect the auth changes.
+                self.__dict__.update(r.__dict__)
 
-            # Recompute Content-Length
-            self.prepare_content_length(self.body)
+                # Recompute Content-Length
+                self.prepare_content_length(self.body)
 
     def prepare_cookies(self, cookies: CookiesType | None) -> None:
         """Prepares the given HTTP cookie data.

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -221,6 +221,7 @@ class Session:
         "_disable_http3",
         "_pool_connections",
         "_pool_maxsize",
+        "_happy_eyeballs",
     ]
 
     def __init__(
@@ -237,6 +238,7 @@ class Session:
         disable_ipv4: bool = False,
         pool_connections: int = DEFAULT_POOLSIZE,
         pool_maxsize: int = DEFAULT_POOLSIZE,
+        happy_eyeballs: bool | int = False,
     ):
         """
         :param resolver: Specify a DNS resolver that should be used within this Session.
@@ -310,6 +312,8 @@ class Session:
         self._pool_connections = pool_connections
         self._pool_maxsize = pool_maxsize
 
+        self._happy_eyeballs = happy_eyeballs
+
         #: SSL Verification default.
         #: Defaults to `True`, requiring requests to verify the TLS certificate at the
         #: remote end.
@@ -364,6 +368,7 @@ class Session:
                 disable_ipv6=disable_ipv6,
                 pool_connections=pool_connections,
                 pool_maxsize=pool_maxsize,
+                happy_eyeballs=happy_eyeballs,
             ),
         )
         self.mount(
@@ -376,6 +381,7 @@ class Session:
                 disable_ipv6=disable_ipv6,
                 pool_connections=pool_connections,
                 pool_maxsize=pool_maxsize,
+                happy_eyeballs=happy_eyeballs,
             ),
         )
 
@@ -1085,6 +1091,7 @@ class Session:
                     0.2 if not strict_ocsp_enabled else 1.0,
                     kwargs["proxies"],
                     resolver=self.resolver,
+                    happy_eyeballs=self._happy_eyeballs,
                 )
 
             # don't trigger pre_send for redirects
@@ -1139,6 +1146,7 @@ class Session:
                     disable_ipv6=self._disable_ipv6,
                     pool_connections=self._pool_connections,
                     pool_maxsize=self._pool_maxsize,
+                    happy_eyeballs=self._happy_eyeballs,
                 ),
             )
             self.mount(
@@ -1151,6 +1159,7 @@ class Session:
                     disable_ipv6=self._disable_ipv6,
                     pool_connections=self._pool_connections,
                     pool_maxsize=self._pool_maxsize,
+                    happy_eyeballs=self._happy_eyeballs,
                 ),
             )
 
@@ -1352,6 +1361,7 @@ class Session:
                 resolver=self.resolver,
                 pool_connections=self._pool_connections,
                 pool_maxsize=self._pool_maxsize,
+                happy_eyeballs=self._happy_eyeballs,
             ),
         )
         self.mount(
@@ -1364,6 +1374,7 @@ class Session:
                 resolver=self.resolver,
                 pool_connections=self._pool_connections,
                 pool_maxsize=self._pool_maxsize,
+                happy_eyeballs=self._happy_eyeballs,
             ),
         )
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 
 import pytest
 
@@ -216,3 +217,14 @@ class TestAsyncWithMultiplex:
         assert len(responses_bar) == 2
 
         assert all(r.status_code == 200 for r in responses_foo + responses_bar)
+
+    @pytest.mark.skipif(os.environ.get("CI") is None, reason="Worth nothing locally")
+    async def test_happy_eyeballs(self) -> None:
+        """A bit of context, this test, running it locally does not get us
+        any confidence about Happy Eyeballs. This test is valuable in Github CI where IPv6 addresses are unreachable.
+        We're using a custom DNS resolver that will yield the IPv6 addresses and IPv4 ones.
+        If this hang in CI, then you did something wrong...!"""
+        async with AsyncSession(resolver="doh+cloudflare://", happy_eyeballs=True) as s:
+            r = await s.get("https://pie.dev/get")
+
+            assert r.ok

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -99,3 +99,14 @@ class TestLiveStandardCase:
         s.get("https://pie.dev/get")
 
         assert s.resolver.is_available()
+
+    @pytest.mark.skipif(os.environ.get("CI") is None, reason="Worth nothing locally")
+    def test_happy_eyeballs(self) -> None:
+        """A bit of context, this test, running it locally does not get us
+        any confidence about Happy Eyeballs. This test is valuable in Github CI where IPv6 addresses are unreachable.
+        We're using a custom DNS resolver that will yield the IPv6 addresses and IPv4 ones.
+        If this hang in CI, then you did something wrong...!"""
+        with Session(resolver="doh+cloudflare://", happy_eyeballs=True) as s:
+            r = s.get("https://pie.dev/get")
+
+            assert r.ok


### PR DESCRIPTION
3.5.5 (2024-03-25)
------------------

**Added**
- Support for Happy Eyeballs. This feature is disabled by default, you must pass `happy_eyeballs=True` within your session constructor or http adapter in order to leverage this.

**Fixed**
- Missed close implementation in AsyncSession causing the underlying poolmanager to remain open.
- Additional OCSP requests (following a redirect) did not use specified custom DNS resolver.

**Changed**
- urllib3.future lower bound constraint has been raised to version 2.7.900 for the newly added happy eyeballs feature.