### PR TITLE
:sparkle: Adjustment for HTTP/3 and OCSP simplifications that came with qh3 1.0+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/|noxfile.py'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.6.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.7.904', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,21 @@
 Release History
 ===============
 
+3.6.0 (2024-04-20)
+------------------
+
+**Added**
+- Support for qh3 version 1.0.0
+  This qh3 release enable a greater flexibility by dropping cryptography. We had to adapt the OCSP code as we
+  relied on cryptography. HTTP/3 experience is greatly improved.
+
+**Changed**
+- urllib3.future lower bound constraint has been raised to version 2.7.904 to ensure support for the last qh3 release.
+
+**Fixed**
+- Improved compatibility with third party mocking tool that are bound to requests.
+- OCSP check did not warn if the HTTP server responded with a non 2xx response in strict mode.
+
 3.5.5 (2024-03-25)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Niquests allows you to send HTTP requests extremely easily. There’s no need to
 [![Downloads](https://static.pepy.tech/badge/niquests/month)](https://pepy.tech/project/niquests)
 [![Supported Versions](https://img.shields.io/pypi/pyversions/niquests.svg)](https://pypi.org/project/niquests)
 
+This project does not require any compilation toolchain. The HTTP/3 support is not enforced and installed if your platform can support it natively _(e.g. pre-built wheel available)_.
+
 ## ✨ Installing Niquests and Supported Versions
 
 Niquests is available on PyPI:

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -118,15 +118,15 @@ Yes... kind of!
 Niquests ships with a nice alternative to ``CaseInsensitiveDict`` that is ``kiss_headers.Headers``.
 You may access it through the ``oheaders`` property of your usual Response, Request and PreparedRequest.
 
-Am I obligated to install qh3 and dependents?
----------------------------------------------
+Am I obligated to install qh3?
+------------------------------
 
 No. But by default, it could be picked for installation. You may remove it safely at the cost
-of loosing HTTP/3 over QUIC.
+of loosing HTTP/3 over QUIC and OCSP certificate revocation status.
 
 A shortcut would be::
 
-    $ pip uninstall qh3 cryptography cffi pycparser
+    $ pip uninstall qh3
 
 .. warning:: Your site-packages is shared, thus it is possible that other libraries depends on some of the listed programs. Do it with care!
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1249,7 +1249,7 @@ a complementary security measure.
 Unless in strict-mode, the proxy configuration will be respected when given, as long as it specify
 a plain ``http`` proxy. This is meant for people who want privacy.
 
-This feature may not be available if the ``cryptography`` package is missing from your environment.
+This feature may not be available if the ``qh3`` package is missing from your environment.
 Verify the availability by running ``python -m niquests.help``.
 
 .. note:: Access property ``ocsp_verified`` in both ``PreparedRequest``, and ``Response`` to have information about this post handshake verification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.7.900,<3",
+    "urllib3.future>=2.7.904,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
@@ -51,14 +51,14 @@ socks = [
     "urllib3.future[socks]",
 ]
 http3 = [
-    "urllib3.future[qh3]"
+    "urllib3.future[qh3]",
 ]
 ocsp = [
-    "cryptography<43.0.0,>=41.0.0"
+    "urllib3.future[qh3]",
 ]
 speedups = [
     "orjson>=3,<4",
-    "urllib3.future[zstd,brotli]"
+    "urllib3.future[zstd,brotli]",
 ]
 
 [project.urls]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.5.5"
+__version__ = "3.6.0"
 
-__build__: int = 0x030505
+__build__: int = 0x030600
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -424,7 +424,7 @@ class AsyncSession(Session):
         request.conn_info = _deepcopy_ci(request.conn_info)
 
         # We are leveraging a multiplexed connection
-        if r.raw is None:
+        if r.lazy is True:
 
             async def _redirect_method_ref(x, y):
                 try:

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import hmac
 import socket
+import ssl
 import typing
 import warnings
 from contextlib import asynccontextmanager
@@ -11,13 +12,12 @@ from hashlib import sha256
 from random import randint
 from statistics import mean
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.hashes import SHA1
-from cryptography.x509 import (
+from qh3._hazmat import (
+    OCSPRequest,
+    OCSPResponse,
+    OCSPResponseStatus,
+    OCSPCertStatus,
     Certificate,
-    load_der_x509_certificate,
-    load_pem_x509_certificate,
-    ocsp,
 )
 
 from .._compat import HAS_LEGACY_URLLIB3
@@ -53,7 +53,7 @@ from ._picotls import (
     async_recv_tls_and_decrypt,
     async_send_tls,
 )
-from ._ocsp import _str_fingerprint_of, _infer_issuer_from
+from ._ocsp import _str_fingerprint_of, readable_revocation_reason
 
 
 async def _ask_nicely_for_issuer(
@@ -165,7 +165,7 @@ async def _ask_nicely_for_issuer(
     certificates = []
 
     for der in der_certificates:
-        certificates.append(load_der_x509_certificate(der))
+        certificates.append(Certificate(der))
 
     await async_send_tls(sock, ALERT, b"\x01\x00")
     sock.close()
@@ -180,15 +180,19 @@ async def _ask_nicely_for_issuer(
 class InMemoryRevocationStatus:
     def __init__(self, max_size: int = 2048):
         self._max_size: int = max_size
-        self._store: dict[str, ocsp.OCSPResponse] = {}
+        self._store: dict[str, OCSPResponse] = {}
         self._semaphores: dict[str, asyncio.Semaphore] = {}
-        self._issuers: list[Certificate] = []
+        self._issuers_map: dict[str, Certificate] = {}
         self._timings: list[datetime.datetime] = []
         self.hold: bool = False
 
-    @property
-    def issuers(self) -> list[Certificate]:
-        return self._issuers
+    def get_issuer_of(self, peer_certificate: Certificate) -> Certificate | None:
+        fingerprint: str = _str_fingerprint_of(peer_certificate)
+
+        if fingerprint not in self._issuers_map:
+            return None
+
+        return self._issuers_map[fingerprint]
 
     def __len__(self) -> int:
         return len(self._store)
@@ -222,7 +226,7 @@ class InMemoryRevocationStatus:
 
         return mean(delays) if delays else 0.0
 
-    def check(self, peer_certificate: Certificate) -> ocsp.OCSPResponse | None:
+    def check(self, peer_certificate: Certificate) -> OCSPResponse | None:
         fingerprint: str = _str_fingerprint_of(peer_certificate)
 
         if fingerprint not in self._store:
@@ -230,11 +234,10 @@ class InMemoryRevocationStatus:
 
         cached_response = self._store[fingerprint]
 
-        if cached_response.certificate_status == ocsp.OCSPCertStatus.GOOD:
+        if cached_response.certificate_status == OCSPCertStatus.GOOD:
             if (
                 cached_response.next_update
-                and datetime.datetime.now().timestamp()
-                >= cached_response.next_update.timestamp()
+                and datetime.datetime.now().timestamp() >= cached_response.next_update
             ):
                 del self._store[fingerprint]
                 return None
@@ -246,18 +249,18 @@ class InMemoryRevocationStatus:
         self,
         peer_certificate: Certificate,
         issuer_certificate: Certificate,
-        ocsp_response: ocsp.OCSPResponse,
+        ocsp_response: OCSPResponse,
     ) -> None:
         if len(self._store) >= self._max_size:
             tbd_key: str | None = None
-            closest_next_update: datetime.datetime | None = None
+            closest_next_update: int | None = None
 
             for k in self._store:
-                if self._store[k].response_status != ocsp.OCSPResponseStatus.SUCCESSFUL:
+                if self._store[k].response_status != OCSPResponseStatus.SUCCESSFUL:
                     tbd_key = k
                     break
 
-                if self._store[k].certificate_status != ocsp.OCSPCertStatus.REVOKED:
+                if self._store[k].certificate_status != OCSPCertStatus.REVOKED:
                     if closest_next_update is None:
                         closest_next_update = self._store[k].next_update
                         tbd_key = k
@@ -268,18 +271,16 @@ class InMemoryRevocationStatus:
 
             if tbd_key:
                 del self._store[tbd_key]
+                del self._issuers_map[tbd_key]
             else:
-                del self._store[list(self._store.keys())[0]]
+                first_key = list(self._store.keys())[0]
+                del self._store[first_key]
+                del self._issuers_map[first_key]
 
-        self._store[_str_fingerprint_of(peer_certificate)] = ocsp_response
+        peer_fingerprint: str = _str_fingerprint_of(peer_certificate)
 
-        issuer_fingerprint = _str_fingerprint_of(issuer_certificate)
-
-        if not any(_str_fingerprint_of(c) == issuer_fingerprint for c in self._issuers):
-            self._issuers.append(issuer_certificate)
-
-        if len(self._issuers) >= self._max_size:
-            self._issuers.pop(0)
+        self._store[peer_fingerprint] = ocsp_response
+        self._issuers_map[peer_fingerprint] = issuer_certificate
 
         self._timings.append(datetime.datetime.now())
 
@@ -308,7 +309,7 @@ async def verify(
     ):
         return
 
-    peer_certificate = load_der_x509_certificate(conn_info.certificate_der)
+    peer_certificate = Certificate(conn_info.certificate_der)
 
     async with _SharedRevocationStatusCache.lock(peer_certificate):
         endpoints: list[str] = [  # type: ignore
@@ -336,23 +337,23 @@ async def verify(
         cached_response = _SharedRevocationStatusCache.check(peer_certificate)
 
         if cached_response is not None:
-            issuer_certificate = _infer_issuer_from(peer_certificate)
+            issuer_certificate = _SharedRevocationStatusCache.get_issuer_of(
+                peer_certificate
+            )
 
             if issuer_certificate:
-                conn_info.issuer_certificate_der = issuer_certificate.public_bytes(
-                    serialization.Encoding.DER
-                )
+                conn_info.issuer_certificate_der = issuer_certificate.public_bytes()
 
-            if cached_response.response_status == ocsp.OCSPResponseStatus.SUCCESSFUL:
-                if cached_response.certificate_status == ocsp.OCSPCertStatus.REVOKED:
+            if cached_response.response_status == OCSPResponseStatus.SUCCESSFUL:
+                if cached_response.certificate_status == OCSPCertStatus.REVOKED:
                     r.ocsp_verified = False
                     raise SSLError(
                         f"""Unable to establish a secure connection to {r.url} because the certificate has been revoked
-                        by issuer ({cached_response.revocation_reason or "unspecified"}).
+                        by issuer ({readable_revocation_reason(cached_response.revocation_reason) or "unspecified"}).
                         You should avoid trying to request anything from it as the remote has been compromised.
                         See https://en.wikipedia.org/wiki/OCSP_stapling for more information."""
                     )
-                elif cached_response.certificate_status == ocsp.OCSPCertStatus.UNKNOWN:
+                elif cached_response.certificate_status == OCSPCertStatus.UNKNOWN:
                     r.ocsp_verified = False
                     if strict is True:
                         raise SSLError(
@@ -381,7 +382,9 @@ async def verify(
             #   - Downloading it using specified caIssuers from the peer certificate.
             if conn_info.issuer_certificate_der is None:
                 # It could be a root (self-signed) certificate. Or a previously seen issuer.
-                issuer_certificate = _infer_issuer_from(peer_certificate)
+                issuer_certificate = _SharedRevocationStatusCache.get_issuer_of(
+                    peer_certificate
+                )
 
                 # If not, try to ask nicely the remote to give us the certificate chain, and extract
                 # from it the immediate issuer.
@@ -406,11 +409,6 @@ async def verify(
                             )
                         else:
                             issuer_certificate = None
-
-                        if issuer_certificate is not None:
-                            peer_certificate.verify_directly_issued_by(
-                                issuer_certificate
-                            )
 
                     except (
                         socket.gaierror,
@@ -448,7 +446,7 @@ async def verify(
                                     b"-----BEGIN CERTIFICATE-----"
                                     not in raw_intermediary_content
                                 ):
-                                    issuer_certificate = load_der_x509_certificate(
+                                    issuer_certificate = Certificate(
                                         raw_intermediary_content
                                     )
                                 # b64 PEM
@@ -456,8 +454,10 @@ async def verify(
                                     b"-----BEGIN CERTIFICATE-----"
                                     in raw_intermediary_content
                                 ):
-                                    issuer_certificate = load_pem_x509_certificate(
-                                        raw_intermediary_content
+                                    issuer_certificate = Certificate(
+                                        ssl.PEM_cert_to_DER_cert(
+                                            raw_intermediary_content.decode()
+                                        )
                                     )
 
                 # Well! We're out of luck. No further should we go.
@@ -471,25 +471,28 @@ async def verify(
                         )
                     return
 
-                conn_info.issuer_certificate_der = issuer_certificate.public_bytes(
-                    serialization.Encoding.DER
-                )
+                conn_info.issuer_certificate_der = issuer_certificate.public_bytes()
             else:
-                issuer_certificate = load_der_x509_certificate(
-                    conn_info.issuer_certificate_der
+                issuer_certificate = Certificate(conn_info.issuer_certificate_der)
+
+            try:
+                req = OCSPRequest(
+                    peer_certificate.public_bytes(), issuer_certificate.public_bytes()
                 )
-
-            builder = ocsp.OCSPRequestBuilder()
-            builder = builder.add_certificate(
-                peer_certificate, issuer_certificate, SHA1()
-            )
-
-            req = builder.build()
+            except ValueError:
+                if strict:
+                    warnings.warn(
+                        f"""Unable to insure that the remote peer ({r.url}) has a currently valid certificate via OCSP.
+                        You are seeing this warning due to enabling strict mode for OCSP / Revocation check.
+                        Reason: The X509 OCSP generator failed to assemble the request""",
+                        SecurityWarning,
+                    )
+                return
 
             try:
                 ocsp_http_response = await session.post(
                     endpoints[randint(0, len(endpoints) - 1)],
-                    data=req.public_bytes(serialization.Encoding.DER),
+                    data=req.public_bytes(),
                     headers={"Content-Type": "application/ocsp-request"},
                     timeout=timeout,
                 )
@@ -510,22 +513,32 @@ async def verify(
                 if ocsp_http_response.content is None:
                     return
 
-                ocsp_resp = ocsp.load_der_ocsp_response(ocsp_http_response.content)
+                try:
+                    ocsp_resp = OCSPResponse(ocsp_http_response.content)
+                except ValueError:
+                    if strict:
+                        warnings.warn(
+                            f"""Unable to insure that the remote peer ({r.url}) has a currently valid certificate via OCSP.
+                            You are seeing this warning due to enabling strict mode for OCSP / Revocation check.
+                            Reason: The X509 OCSP parser failed to read the response""",
+                            SecurityWarning,
+                        )
+                    return
 
                 _SharedRevocationStatusCache.save(
                     peer_certificate, issuer_certificate, ocsp_resp
                 )
 
-                if ocsp_resp.response_status == ocsp.OCSPResponseStatus.SUCCESSFUL:
-                    if ocsp_resp.certificate_status == ocsp.OCSPCertStatus.REVOKED:
+                if ocsp_resp.response_status == OCSPResponseStatus.SUCCESSFUL:
+                    if ocsp_resp.certificate_status == OCSPCertStatus.REVOKED:
                         r.ocsp_verified = False
                         raise SSLError(
                             f"""Unable to establish a secure connection to {r.url} because the certificate has been revoked
-                            by issuer ({ocsp_resp.revocation_reason or "unspecified"}).
+                            by issuer ({readable_revocation_reason(ocsp_resp.revocation_reason) or "unspecified"}).
                             You should avoid trying to request anything from it as the remote has been compromised.
                             See https://en.wikipedia.org/wiki/OCSP_stapling for more information."""
                         )
-                    if ocsp_resp.certificate_status == ocsp.OCSPCertStatus.UNKNOWN:
+                    if ocsp_resp.certificate_status == OCSPCertStatus.UNKNOWN:
                         r.ocsp_verified = False
                         if strict is True:
                             raise SSLError(
@@ -543,6 +556,14 @@ async def verify(
                             OCSP Server Status: {ocsp_resp.response_status}""",
                             SecurityWarning,
                         )
+            else:
+                if strict:
+                    warnings.warn(
+                        f"""Unable to insure that the remote peer ({r.url}) has a currently valid certificate via OCSP.
+                            You are seeing this warning due to enabling strict mode for OCSP / Revocation check.
+                            OCSP Server Status: {str(ocsp_http_response)}""",
+                        SecurityWarning,
+                    )
 
 
 __all__ = ("verify",)

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -39,11 +39,6 @@ except ImportError:
     certifi = None  # type: ignore
 
 try:
-    import cryptography  # type: ignore
-except ImportError:
-    cryptography = None  # type: ignore
-
-try:
     from .extensions._ocsp import verify as ocsp_verify
 except ImportError:
     ocsp_verify = None  # type: ignore
@@ -105,9 +100,6 @@ def info():
 
     charset_normalizer_info = {"version": charset_normalizer.__version__}
 
-    cryptography_info = {
-        "version": getattr(cryptography, "__version__", ""),
-    }
     idna_info = {
         "version": getattr(idna, "__version__", ""),
     }
@@ -123,7 +115,6 @@ def info():
         "system_ssl": system_ssl_info,
         "urllib3.future": urllib3_info,
         "charset_normalizer": charset_normalizer_info,
-        "cryptography": cryptography_info,
         "idna": idna_info,
         "niquests": {
             "version": niquests_version,

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1188,7 +1188,7 @@ class Session:
         request.conn_info = _deepcopy_ci(request.conn_info)
 
         # We are leveraging a multiplexed connection
-        if r.raw is None:
+        if r.lazy is True:
             r._resolve_redirect = lambda x, y: next(
                 self.resolve_redirects(x, y, yield_requests=True, **kwargs),  # type: ignore
                 None,


### PR DESCRIPTION
3.6.0 (2024-04-20)
------------------

**Added**
- Support for qh3 version 1.0.0
  This qh3 release enable a greater flexibility by dropping cryptography. We had to adapt the OCSP code as we
  relied on cryptography. HTTP/3 experience is greatly improved.

**Changed**
- urllib3.future lower bound constraint has been raised to version 2.7.904 to ensure support for the last qh3 release.

**Fixed**
- Improved compatibility with third party mocking tool that are bound to requests.
- OCSP check did not warn if the HTTP server responded with a non 2xx response in strict mode.
