### PR TITLE
:bug: Improve handling broken environment with a graceful error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.6.1 (2024-04-21)
+------------------
+
+**Fixed**
+- Handling broken environments with a graceful exception with a detailed error message.
+
 3.6.0 (2024-04-20)
 ------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 
-__build__: int = 0x030600
+__build__: int = 0x030601
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_compat.py
+++ b/src/niquests/_compat.py
@@ -22,7 +22,21 @@ try:
 except ImportError:
     urllib3 = None  # type: ignore[assignment]
 
-T = typing.TypeVar("T", urllib3.Timeout, urllib3.Retry)
+
+if (urllib3 is None and urllib3_future is None) or (
+    HAS_LEGACY_URLLIB3 and urllib3_future is None
+):
+    raise RuntimeError(
+        "This is awkward but your environment is missing urllib3-future. "
+        "Your environment seems broken. "
+        "You may fix this issue by running `python -m pip install niquests -U` "
+        "to force reinstall its dependencies."
+    )
+
+if urllib3 is not None:
+    T = typing.TypeVar("T", urllib3.Timeout, urllib3.Retry)
+else:
+    T = typing.TypeVar("T", urllib3_future.Timeout, urllib3_future.Retry)  # type: ignore
 
 
 def urllib3_ensure_type(o: T) -> T:


### PR DESCRIPTION
Came up with someone that attempted to break his environment by doing:

```
pip install niquests requests
pip uninstall requests urllib3
python -c "import niquests"
```

in the given order.