### PR TITLE
:bookmark: Release 3.6.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-13, windows-latest]
         include:
           # pypy-3.7, pypy-3.8 may fail due to missing cryptography wheels. Adapting.
           - python-version: pypy-3.7
@@ -29,7 +29,7 @@ jobs:
           - python-version: pypy-3.8
             os: ubuntu-latest
           - python-version: pypy-3.8
-            os: macOS-latest
+            os: macOS-13
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,16 @@
 Release History
 ===============
 
+3.6.2 (2024-05-02)
+------------------
+
+**Fixed**
+- "Help" program `python -m niquests.help` that depended on h2 while not required anymore.
+- Minor performance regression in async while checking OCSP when certificate isn't eligible (e.g. no OCSP url provided).
+
+**Changed**
+- urllib3.future lower bound constraint has been raised to version 2.7.905 to ensure inclusion of jh2 instead of h2.
+
 3.6.1 (2024-04-22)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.md LICENSE NOTICE HISTORY.md requirements-dev.txt
+include README.md SECURITY.md LICENSE NOTICE HISTORY.md requirements-dev.txt
 recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -48,20 +48,20 @@ _Scenario:_ Fetch a thousand requests using 10 tasks or threads, each with a hun
 
 **High-Level APIs**
 
-| Client   | Average Delay to Complete                | Notes                        |
-|----------|------------------------------------------|------------------------------|
-| requests | <span style="color:red">987 ms</span>    | ThreadPoolExecutor. HTTP/1.1 |
-| httpx    | <span style="color:orange">735 ms</span> | Asyncio. HTTP/2              |
-| niquests | <span style="color:green">470 ms</span>  | Asyncio. HTTP/2              |
+| Client   | Average Delay to Complete | Notes                        |
+|----------|---------------------------|------------------------------|
+| requests | 987 ms                    | ThreadPoolExecutor. HTTP/1.1 |
+| httpx    | 735 ms                    | Asyncio. HTTP/2              |
+| niquests | 400 ms                    | Asyncio. HTTP/2              |
 
 **Simplified APIs**
 
-| Client        | Average Delay to Complete                | Notes                        |
-|---------------|------------------------------------------|------------------------------|
-| requests core | <span style="color:red">643 ms</span>    | ThreadPoolExecutor. HTTP/1.1 |
-| httpx core    | <span style="color:orange">550 ms</span> | Asyncio. HTTP/2              |
-| aiohttp       | <span style="color:green">220 ms</span>  | Asyncio. HTTP/1.1            |
-| niquests core | <span style="color:green">210 ms</span>  | Asyncio. HTTP/2              |
+| Client        | Average Delay to Complete | Notes                        |
+|---------------|---------------------------|------------------------------|
+| requests core | 643 ms                    | ThreadPoolExecutor. HTTP/1.1 |
+| httpx core    | 550 ms                    | Asyncio. HTTP/2              |
+| aiohttp       | 220 ms                    | Asyncio. HTTP/1.1            |
+| niquests core | 190 ms                    | Asyncio. HTTP/2              |
 
 Did you give up on HTTP/2 due to performance concerns? Think again! Multiplexing and response lazyness open up a wide range
 of possibilities! Want to learn more about the tests? scripts? reasoning?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.7.904,<3",
+    "urllib3.future>=2.7.905,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
@@ -75,14 +75,14 @@ include = [
     "/docs",
     "/src",
     "/tests",
-    "/dev-requirements.txt",
+    "/requirements-dev.txt",
     "/HISTORY.md",
     "/README.md",
+    "/SECURITY.md",
     "/AUTHORS.rst",
     "/LICENSE",
     "/NOTICE",
     "/Makefile",
-    "/setup.cfg",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.6.1"
+__version__ = "3.6.2"
 
-__build__: int = 0x030601
+__build__: int = 0x030602
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -309,20 +309,20 @@ async def verify(
     ):
         return
 
+    endpoints: list[str] = [  # type: ignore
+        # exclude non-HTTP endpoint. like ldap.
+        ep  # type: ignore
+        for ep in list(conn_info.certificate_dict.get("OCSP", []))  # type: ignore
+        if ep.startswith("http://")  # type: ignore
+    ]
+
+    # well... not all issued certificate have a OCSP entry. e.g. mkcert.
+    if not endpoints:
+        return
+
     peer_certificate = Certificate(conn_info.certificate_der)
 
     async with _SharedRevocationStatusCache.lock(peer_certificate):
-        endpoints: list[str] = [  # type: ignore
-            # exclude non-HTTP endpoint. like ldap.
-            ep  # type: ignore
-            for ep in list(conn_info.certificate_dict.get("OCSP", []))  # type: ignore
-            if ep.startswith("http://")  # type: ignore
-        ]
-
-        # well... not all issued certificate have a OCSP entry. e.g. mkcert.
-        if not endpoints:
-            return
-
         # this feature, by default, is reserved for a reasonable usage.
         if not strict:
             mean_rate_sec = _SharedRevocationStatusCache.rate()

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -10,7 +10,7 @@ import warnings
 from json import JSONDecodeError
 
 import charset_normalizer
-import h2  # type: ignore
+import jh2  # type: ignore
 import h11
 import idna
 import wassima
@@ -128,7 +128,7 @@ def info():
             "qh3": qh3.__version__ if qh3 is not None else None,
         },
         "http2": {
-            "h2": h2.__version__,
+            "jh2": jh2.__version__,
         },
         "http1": {
             "h11": h11.__version__,


### PR DESCRIPTION
**Fixed**
- "Help" program `python -m niquests.help` that depended on h2 while not required anymore.
- Minor performance regression in async while checking OCSP when certificate isn't eligible (e.g. no OCSP url provided).