### PR TITLE
🐛 Fix encoding data with None values and more

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -747,7 +747,7 @@ class PreparedRequest:
                 ):
                     # not officially supported, but some people maybe passing ints, float, bool,
                     # or other string serializable classes.
-                    if not isinstance(vs, (str, bytes, type(None))):
+                    if vs is not None and not isinstance(vs, (str, bytes,)):
                         iterable_vs = [str(vs)]
                     else:
                         iterable_vs = [vs]

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -747,7 +747,7 @@ class PreparedRequest:
                 ):
                     # not officially supported, but some people maybe passing ints, float, bool,
                     # or other string serializable classes.
-                    if not isinstance(vs, (str, bytes)):
+                    if not isinstance(vs, (str, bytes, type(None))):
                         iterable_vs = [str(vs)]
                     else:
                         iterable_vs = [vs]

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -742,9 +742,12 @@ class PreparedRequest:
             result = []
             for k, vs in to_key_val_list(data):
                 iterable_vs: typing.Iterable[str | bytes]
-                if isinstance(vs, (str, bytes, int, float, bool)):
-                    # not officially supported, but some people maybe passing ints, float or bool.
-                    if isinstance(vs, (str, bytes)) is False:
+                if isinstance(vs, (str, bytes, int, float, bool)) or not hasattr(
+                    vs, "__iter__"
+                ):
+                    # not officially supported, but some people maybe passing ints, float, bool,
+                    # or other string serializable classes.
+                    if not isinstance(vs, (str, bytes)):
                         iterable_vs = [str(vs)]
                     else:
                         iterable_vs = [vs]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2548,18 +2548,28 @@ def test_data_ecodes_noniterables():
         def __str__(self):
             return "🔥arbClassStringable🔥"
 
+    ClassObj = Class()
+
     body = {
         "string": "string",
         "float": 0.01,
         "int": 100,
         "bool": True,
         "None": None,
-        "plain_class": Class(),
+        "plain_class": ClassObj,
         "stringable_class": ClassStringable(),
     }
-    p = PreparedRequest()
-    p.prepare(method="post", url="https://www.example.com/", data=body)
-    assert isinstance(p.body, str)
+
+    expected_response = {
+        "bool": "True",
+        "float": "0.01",
+        "int": "100",
+        "plain_class": str(ClassObj),
+        "string": "string",
+        "stringable_class": "🔥arbClassStringable🔥",
+    }
+    resp = niquests.post(url="https://httpbin.org/post", data=body)
+    assert resp.json()["form"] == expected_response
 
 
 def test_requests_are_updated_each_time(httpbin):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2540,7 +2540,7 @@ def test_json_encodes_as_bytes():
     assert isinstance(p.body, bytes)
 
 
-def test_data_ecodes_noniterables():
+def test_data_encodes_noniterables(httpbin):
     class Class:
         pass
 
@@ -2552,6 +2552,7 @@ def test_data_ecodes_noniterables():
 
     body = {
         "string": "string",
+        "bytes": b"string",
         "float": 0.01,
         "int": 100,
         "bool": True,
@@ -2566,9 +2567,10 @@ def test_data_ecodes_noniterables():
         "int": "100",
         "plain_class": str(ClassObj),
         "string": "string",
+        "bytes": "bytes",
         "stringable_class": "🔥arbClassStringable🔥",
     }
-    resp = niquests.post(url="https://httpbin.org/post", data=body)
+    resp = niquests.post(httpbin("post"), data=body)
     assert resp.json()["form"] == expected_response
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2567,7 +2567,7 @@ def test_data_encodes_noniterables(httpbin):
         "int": "100",
         "plain_class": str(ClassObj),
         "string": "string",
-        "bytes": "bytes",
+        "bytes": "string",
         "stringable_class": "🔥arbClassStringable🔥",
     }
     resp = niquests.post(httpbin("post"), data=body)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2540,6 +2540,28 @@ def test_json_encodes_as_bytes():
     assert isinstance(p.body, bytes)
 
 
+def test_data_ecodes_noniterables():
+    class Class:
+        pass
+
+    class ClassStringable:
+        def __str__(self):
+            return "🔥arbClassStringable🔥"
+
+    body = {
+        "string": "string",
+        "float": 0.01,
+        "int": 100,
+        "bool": True,
+        "None": None,
+        "plain_class": Class(),
+        "stringable_class": ClassStringable(),
+    }
+    p = PreparedRequest()
+    p.prepare(method="post", url="https://www.example.com/", data=body)
+    assert isinstance(p.body, str)
+
+
 def test_requests_are_updated_each_time(httpbin):
     session = RedirectSession([303, 307])
     prep = niquests.Request("POST", httpbin("post")).prepare()


### PR DESCRIPTION
This addresses #118, inspired by the code in [requests](https://github.com/psf/requests/blob/2d5f54779ad174035c5437b3b3c1146b0eaf60fe/src/requests/models.py#L122).

Essentially this PR will allow encoding any non-iterable object as string. This is a general solution to the specific problem in #118. Since `None` is not iterable, it is encoded "None". Similarly, any non-iterable object will be encoded as `str(obj)`.
