### PR TITLE
remove unused `disable_thread: bool = False  # no-op since v3.5`

### DIFF
--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -113,8 +113,6 @@ class AsyncSession(Session):
       <Response HTTP/2 [200]>
     """
 
-    disable_thread: bool = False  # no-op since v3.5
-
     def __init__(
         self,
         *,


### PR DESCRIPTION
hi, you resolve this issue #79 in PR #87  and this true. However, you still have an unused attribute
I re-checked the generation of threads and indeed the work is happening in one thread, and you can see it under the hood, thanks
```python
import niquests
import threading
import asyncio

async def main():
    s = niquests.AsyncSession()
    print(threading.enumerate())
    task1 = asyncio.create_task(s.get('https://google.com/search?q=hi'))
    task2 = asyncio.create_task(s.get('https://google.com/search?q=привет'))
    print(threading.enumerate())
    await task1
    await task2

if __name__ == "__main__":
    asyncio.run(main())
```

result
```text
[<_MainThread(MainThread, started 6712)>]
[<_MainThread(MainThread, started 6712)>]
```