### PR TITLE
:zap: Lazy load the OCSP extension in order to improve the import performance

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 Release History
 ===============
 
-3.6.5 (2024-05-??)
+3.6.5 (2024-05-22)
 ------------------
 
 **Fixed**
@@ -11,6 +11,12 @@ Release History
   allowing it. Reported in https://github.com/httpie/cli/issues/602
   `RequestsCookieJar` set a default policy that circumvent that limitation, if you specified a custom cookie policy then this
   fix won't be applied.
+
+**Changed**
+- Lazy load the OCSP extension in order to improve the import performance.
+
+**Removed**
+- Class variable `disable_thread` in `AsyncSession` that is no longer relevant since the native asyncio implementation. (PR #122)
 
 3.6.4 (2024-05-16)
 ------------------

--- a/src/niquests/__init__.py
+++ b/src/niquests/__init__.py
@@ -54,10 +54,6 @@ else:
 
 # urllib3's DependencyWarnings should be silenced.
 warnings.simplefilter("ignore", DependencyWarning)
-# Commonly happen on Windows due to some legacy root CA in
-# their trust store. They are aware of it, we silent the warning
-# yield by Cryptography to avoid producing undesired noise to end-users.
-warnings.filterwarnings("ignore", "Parsed a negative serial number")
 
 # ruff: noqa: E402
 from . import utils

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -1173,3 +1173,26 @@ def parse_scheme(url: str, default: str | None = None, max_length: int = 9) -> s
         ) from e
 
     return scheme.lower()
+
+
+def is_ocsp_capable(conn_info: ConnectionInfo | None) -> bool:
+    # we can't do anything in that case.
+    if (
+        conn_info is None
+        or conn_info.certificate_der is None
+        or conn_info.certificate_dict is None
+    ):
+        return False
+
+    endpoints: list[str] = [  # type: ignore
+        # exclude non-HTTP endpoint. like ldap.
+        ep  # type: ignore
+        for ep in list(conn_info.certificate_dict.get("OCSP", []))  # type: ignore
+        if ep.startswith("http://")  # type: ignore
+    ]
+
+    # well... not all issued certificate have a OCSP entry. e.g. mkcert.
+    if not endpoints:
+        return False
+
+    return True


### PR DESCRIPTION
3.6.5 (2024-05-22)
------------------

**Fixed**
- Support `localhost` as a valid domain for cookies. The standard library does not allow this special
  domain. Researches showed that a valid domain should have at least two dots (e.g. abc.com. and xyz.tld. but not com.).
  Public suffixes cannot be used as a cookie domain for security reasons, but as `localhost` isn't one we are explicitly
  allowing it. Reported in https://github.com/httpie/cli/issues/602
  `RequestsCookieJar` set a default policy that circumvent that limitation, if you specified a custom cookie policy then this
  fix won't be applied.

**Changed**
- Lazy load the OCSP extension in order to improve the import performance.

**Removed**
- Class variable `disable_thread` in `AsyncSession` that is no longer relevant since the native asyncio implementation. (PR #122)
