### PR TITLE
:bookmark: Release 3.7.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,26 @@
 Release History
 ===============
 
+3.7.0 (2024-06-24)
+------------------
+
+**Added**
+- TransferProgress tracking in Response when downloading using `stream=True` based on the Content-Length. (#127)
+  There's no easy way to track the "real" amount of bytes consumed using "iter_content" when the remote is
+  sending a compressed body. This change makes it possible to track the amount of bytes consumed.
+  The `Response` object now contain a property named `download_progress` that is either `None` or a `TransferProgress` object.
+- HTTP/2 with prior knowledge over TLS or via an unencrypted connection.
+  `disable_http1` toggle is now available through your `Session` constructor.
+  In consequence, you may leverage all HTTP/2 capabilities like multiplexing using a plain (e.g. non-TLS) socket.
+  You may enable/disable any protocols per Session object (but not all of them at once!).
+  In non-TLS connections, you have to keep one of HTTP/1.1 or HTTP/2 enabled.
+  Otherwise, one of HTTP/1.1, HTTP/2 or HTTP/3. A `RuntimeError` may be thrown if no protocol can be used in a
+  given context.
+
+**Changed**
+- Relax main API constraint in get, head, options and delete methods / functions by accepting kwargs.
+- urllib3-future lower bound version is raised to 2.8.900
+
 3.6.7 (2024-06-19)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `Direct HTTP/3 Negotiation`         |  ✅[^9]   |  N/A[^8]  |    N/A[^8]    | N/A[^8]       |
 | `Happy Eyeballs`                    |    ✅     |     ❌     |       ❌       | ✅             |
 | `Package / SLSA Signed`             |    ✅     |     ❌     |       ❌       | ✅             |
+| `HTTP/2 with prior knowledge (h2c)` |    ✅     |     ❌     |       ✅       | ❌             |
 </details>
 
 <details>
@@ -144,6 +145,7 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - Basic & Digest Authentication
 - Familiar `dict`–like Cookies
 - Network settings fine-tuning
+- HTTP/2 with prior knowledge
 - Object-oriented headers
 - Multi-part File Uploads
 - Chunked HTTP Requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.7.905,<3",
+    "urllib3.future>=2.8.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.6.7"
+__version__ = "3.7.0"
 
-__build__: int = 0x030607
+__build__: int = 0x030700
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -117,6 +117,7 @@ class AsyncSession(Session):
         quic_cache_layer: CacheLayerAltSvcType | None = None,
         retries: RetryType = DEFAULT_RETRIES,
         multiplexed: bool = False,
+        disable_http1: bool = False,
         disable_http2: bool = False,
         disable_http3: bool = False,
         disable_ipv6: bool = False,
@@ -177,6 +178,7 @@ class AsyncSession(Session):
         #: Bind to address/network adapter
         self.source_address = source_address
 
+        self._disable_http1 = disable_http1
         self._disable_http2 = disable_http2
         self._disable_http3 = disable_http3
 
@@ -797,6 +799,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[False] = ...,
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> Response: ...
 
     @typing.overload  # type: ignore[override]
@@ -815,6 +818,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> AsyncResponse: ...
 
     async def get(  # type: ignore[override]
@@ -832,6 +836,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
             "GET",
@@ -847,6 +852,7 @@ class AsyncSession(Session):
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     @typing.overload  # type: ignore[override]
@@ -865,6 +871,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[False] = ...,
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> Response: ...
 
     @typing.overload  # type: ignore[override]
@@ -883,6 +890,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> AsyncResponse: ...
 
     async def options(  # type: ignore[override]
@@ -900,6 +908,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
             "OPTIONS",
@@ -915,6 +924,7 @@ class AsyncSession(Session):
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     @typing.overload  # type: ignore[override]
@@ -933,6 +943,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[False] = ...,
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> Response: ...
 
     @typing.overload  # type: ignore[override]
@@ -951,6 +962,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> AsyncResponse: ...
 
     async def head(  # type: ignore[override]
@@ -968,6 +980,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
             "HEAD",
@@ -983,6 +996,7 @@ class AsyncSession(Session):
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     @typing.overload  # type: ignore[override]
@@ -1241,6 +1255,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[False] = ...,
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> Response: ...
 
     @typing.overload  # type: ignore[override]
@@ -1259,6 +1274,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
+        **kwargs: typing.Any,
     ) -> AsyncResponse: ...
 
     async def delete(  # type: ignore[override]
@@ -1276,6 +1292,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
             "DELETE",
@@ -1291,6 +1308,7 @@ class AsyncSession(Session):
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     async def gather(self, *responses: Response, max_fetch: int | None = None) -> None:  # type: ignore[override]

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -313,6 +313,7 @@ class HTTPAdapter(BaseAdapter):
         "_pool_maxsize",
         "_pool_block",
         "_quic_cache_layer",
+        "_disable_http1",
         "_disable_http2",
         "_disable_http3",
         "_source_address",
@@ -327,7 +328,9 @@ class HTTPAdapter(BaseAdapter):
         pool_maxsize: int = DEFAULT_POOLSIZE,
         max_retries: RetryType = DEFAULT_RETRIES,
         pool_block: bool = DEFAULT_POOLBLOCK,
+        *,  # todo: revert if any complaint about it... :s
         quic_cache_layer: CacheLayerAltSvcType | None = None,
+        disable_http1: bool = False,
         disable_http2: bool = False,
         disable_http3: bool = False,
         max_in_flight_multiplexed: int | None = None,
@@ -359,6 +362,7 @@ class HTTPAdapter(BaseAdapter):
         self._pool_maxsize = pool_maxsize
         self._pool_block = pool_block
         self._quic_cache_layer = quic_cache_layer
+        self._disable_http1 = disable_http1
         self._disable_http2 = disable_http2
         self._disable_http3 = disable_http3
         self._resolver = resolver
@@ -379,6 +383,8 @@ class HTTPAdapter(BaseAdapter):
 
         disabled_svn = set()
 
+        if disable_http1:
+            disabled_svn.add(HttpVersion.h11)
         if disable_http2:
             disabled_svn.add(HttpVersion.h2)
         if disable_http3:
@@ -412,6 +418,8 @@ class HTTPAdapter(BaseAdapter):
 
         disabled_svn = set()
 
+        if self._disable_http1:
+            disabled_svn.add(HttpVersion.h11)
         if self._disable_http2:
             disabled_svn.add(HttpVersion.h2)
         if self._disable_http3:
@@ -1284,6 +1292,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         "_pool_maxsize",
         "_pool_block",
         "_quic_cache_layer",
+        "_disable_http1",
         "_disable_http2",
         "_disable_http3",
         "_source_address",
@@ -1298,7 +1307,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         pool_maxsize: int = DEFAULT_POOLSIZE,
         max_retries: RetryType = DEFAULT_RETRIES,
         pool_block: bool = DEFAULT_POOLBLOCK,
+        *,
         quic_cache_layer: CacheLayerAltSvcType | None = None,
+        disable_http1: bool = False,
         disable_http2: bool = False,
         disable_http3: bool = False,
         max_in_flight_multiplexed: int | None = None,
@@ -1331,6 +1342,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         self._pool_maxsize = pool_maxsize
         self._pool_block = pool_block
         self._quic_cache_layer = quic_cache_layer
+        self._disable_http1 = disable_http1
         self._disable_http2 = disable_http2
         self._disable_http3 = disable_http3
         self._resolver = resolver
@@ -1350,6 +1362,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
 
         disabled_svn = set()
 
+        if disable_http1:
+            disabled_svn.add(HttpVersion.h11)
         if disable_http2:
             disabled_svn.add(HttpVersion.h2)
         if disable_http3:
@@ -1383,6 +1397,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
 
         disabled_svn = set()
 
+        if self._disable_http1:
+            disabled_svn.add(HttpVersion.h11)
         if self._disable_http2:
             disabled_svn.add(HttpVersion.h2)
         if self._disable_http3:

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -139,6 +139,7 @@ def get(
     cert: TLSClientCertType | None = None,
     hooks: HookType[PreparedRequest | Response] | None = None,
     retries: RetryType = DEFAULT_RETRIES,
+    **kwargs: typing.Any,
 ) -> Response:
     r"""Sends a GET request.
 
@@ -182,6 +183,7 @@ def get(
         cert=cert,
         hooks=hooks,
         retries=retries,
+        **kwargs,
     )
 
 
@@ -200,6 +202,7 @@ def options(
     cert: TLSClientCertType | None = None,
     hooks: HookType[PreparedRequest | Response] | None = None,
     retries: RetryType = DEFAULT_RETRIES,
+    **kwargs: typing.Any,
 ) -> Response:
     r"""Sends an OPTIONS request.
 
@@ -242,6 +245,7 @@ def options(
         cert=cert,
         hooks=hooks,
         retries=retries,
+        **kwargs,
     )
 
 
@@ -260,6 +264,7 @@ def head(
     cert: TLSClientCertType | None = None,
     hooks: HookType[PreparedRequest | Response] | None = None,
     retries: RetryType = DEFAULT_RETRIES,
+    **kwargs: typing.Any,
 ) -> Response:
     r"""Sends a HEAD request.
 
@@ -302,6 +307,7 @@ def head(
         cert=cert,
         hooks=hooks,
         retries=retries,
+        **kwargs,
     )
 
 
@@ -542,6 +548,7 @@ def delete(
     cert: TLSClientCertType | None = None,
     hooks: HookType[PreparedRequest | Response] | None = None,
     retries: RetryType = DEFAULT_RETRIES,
+    **kwargs: typing.Any,
 ) -> Response:
     r"""Sends a DELETE request.
 
@@ -584,4 +591,5 @@ def delete(
         cert=cert,
         hooks=hooks,
         retries=retries,
+        **kwargs,
     )

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -222,6 +222,7 @@ class Session:
         "source_address",
         "_disable_ipv4",
         "_disable_ipv6",
+        "_disable_http1",
         "_disable_http2",
         "_disable_http3",
         "_pool_connections",
@@ -237,6 +238,7 @@ class Session:
         quic_cache_layer: CacheLayerAltSvcType | None = None,
         retries: RetryType = DEFAULT_RETRIES,
         multiplexed: bool = False,
+        disable_http1: bool = False,
         disable_http2: bool = False,
         disable_http3: bool = False,
         disable_ipv6: bool = False,
@@ -308,6 +310,7 @@ class Session:
         #: Bind to address/network adapter
         self.source_address = source_address
 
+        self._disable_http1 = disable_http1
         self._disable_http2 = disable_http2
         self._disable_http3 = disable_http3
 
@@ -365,6 +368,7 @@ class Session:
             HTTPAdapter(
                 quic_cache_layer=self.quic_cache_layer,
                 max_retries=retries,
+                disable_http1=disable_http1,
                 disable_http2=disable_http2,
                 disable_http3=disable_http3,
                 resolver=resolver,
@@ -382,6 +386,8 @@ class Session:
                 max_retries=retries,
                 resolver=resolver,
                 source_address=source_address,
+                disable_http1=disable_http1,
+                disable_http2=disable_http2,
                 disable_ipv4=disable_ipv4,
                 disable_ipv6=disable_ipv6,
                 pool_connections=pool_connections,
@@ -560,6 +566,7 @@ class Session:
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response:
         r"""Sends a GET request. Returns :class:`Response` object.
 
@@ -609,6 +616,7 @@ class Session:
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     def options(
@@ -626,6 +634,7 @@ class Session:
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response:
         r"""Sends a OPTIONS request. Returns :class:`Response` object.
 
@@ -675,6 +684,7 @@ class Session:
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     def head(
@@ -692,6 +702,7 @@ class Session:
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response:
         r"""Sends a HEAD request. Returns :class:`Response` object.
 
@@ -741,6 +752,7 @@ class Session:
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     def post(
@@ -992,6 +1004,7 @@ class Session:
         verify: TLSVerifyType = True,
         stream: bool = False,
         cert: TLSClientCertType | None = None,
+        **kwargs: typing.Any,
     ) -> Response:
         r"""Sends a DELETE request. Returns :class:`Response` object.
 
@@ -1041,6 +1054,7 @@ class Session:
             verify=verify,
             stream=stream,
             cert=cert,
+            **kwargs,
         )
 
     def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response:
@@ -1148,6 +1162,7 @@ class Session:
                 HTTPAdapter(
                     quic_cache_layer=self.quic_cache_layer,
                     max_retries=self.retries,
+                    disable_http1=self._disable_http1,
                     disable_http2=self._disable_http2,
                     disable_http3=self._disable_http3,
                     resolver=self.resolver,
@@ -1163,6 +1178,8 @@ class Session:
                 "http://",
                 HTTPAdapter(
                     max_retries=self.retries,
+                    disable_http1=self._disable_http1,
+                    disable_http2=self._disable_http2,
                     resolver=self.resolver,
                     source_address=self.source_address,
                     disable_ipv4=self._disable_ipv4,


### PR DESCRIPTION
**Added**
- TransferProgress tracking in Response when downloading using `stream=True` based on the Content-Length. (#127) There's no easy way to track the "real" amount of bytes consumed using "iter_content" when the remote is sending a compressed body. This change makes it possible to track the amount of bytes consumed. The `Response` object now contain a property named `download_progress` that is either `None` or a `TransferProgress` object.
- HTTP/2 with prior knowledge over TLS or via an unencrypted connection. `disable_http1` toggle is now available through your `Session` constructor. In consequence, you may leverage all HTTP/2 capabilities like multiplexing using a plain (e.g. non-TLS) socket. You may enable/disable any protocols per Session object (but not all of them at once!). In non-TLS connections, you have to keep one of HTTP/1.1 or HTTP/2 enabled. Otherwise, one of HTTP/1.1, HTTP/2 or HTTP/3. A `RuntimeError` may be thrown if no protocol can be used in a given context.

**Changed**
- Relax main API constraint in get, head, options and delete methods / functions by accepting kwargs.
- urllib3-future lower bound version is raised to 2.8.900