### PR TITLE
Fix HttpAuthenticationType to add callable

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.7.1 (2024-06-??)
+------------------
+
+**Fixed**
+- auth argument not accepting a function according to static type checkers. (#133)
+
 3.7.0 (2024-06-24)
 ------------------
 

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -25,13 +25,12 @@ else:
 
 from .auth import AuthBase
 from .structures import CaseInsensitiveDict
+
 if typing.TYPE_CHECKING:
     from .models import PreparedRequest
 
 #: (Restricted) list of http verb that we natively support and understand.
-HttpMethodType: typing.TypeAlias = (
-    str  # todo: have typing.Literal when ready to drop Python 3.7
-)
+HttpMethodType: typing.TypeAlias = str
 #: List of formats accepted for URL queries parameters. (e.g. /?param1=a&param2=b)
 QueryParameterType: typing.TypeAlias = typing.Union[
     typing.List[typing.Tuple[str, typing.Union[str, typing.List[str]]]],
@@ -87,12 +86,12 @@ TimeoutType: typing.TypeAlias = typing.Union[
 ]
 #: Specify (BasicAuth) authentication by passing a tuple of user, and password.
 #: Can be a custom authentication mechanism that derive from AuthBase.
-HttpAuthenticationType: typing.TypeAlias = """typing.Union[
+HttpAuthenticationType: typing.TypeAlias = typing.Union[
     typing.Tuple[typing.Union[str, bytes], typing.Union[str, bytes]],
     str,
     AuthBase,
-    typing.Callable[[PreparedRequest], PreparedRequest],
-]"""
+    typing.Callable[["PreparedRequest"], "PreparedRequest"],
+]
 #: Map for each protocol (http, https) associated proxy to be used.
 ProxyType: typing.TypeAlias = typing.Dict[str, str]
 

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -25,6 +25,8 @@ else:
 
 from .auth import AuthBase
 from .structures import CaseInsensitiveDict
+if typing.TYPE_CHECKING:
+    from .models import PreparedRequest
 
 #: (Restricted) list of http verb that we natively support and understand.
 HttpMethodType: typing.TypeAlias = (
@@ -85,11 +87,12 @@ TimeoutType: typing.TypeAlias = typing.Union[
 ]
 #: Specify (BasicAuth) authentication by passing a tuple of user, and password.
 #: Can be a custom authentication mechanism that derive from AuthBase.
-HttpAuthenticationType: typing.TypeAlias = typing.Union[
+HttpAuthenticationType: typing.TypeAlias = """typing.Union[
     typing.Tuple[typing.Union[str, bytes], typing.Union[str, bytes]],
     str,
     AuthBase,
-]
+    typing.Callable[[PreparedRequest], PreparedRequest],
+]"""
 #: Map for each protocol (http, https) associated proxy to be used.
 ProxyType: typing.TypeAlias = typing.Dict[str, str]
 


### PR DESCRIPTION
Add a callable object to the `HttpAuthenticationType` type definition.

A type checking error occurs when a callable object is given as the `auth` argument.

![image](https://github.com/jawah/niquests/assets/51289448/a460196f-1a9f-4831-a56d-1a992e85da30)

<details>
<summary>Reproduction code</summary>

```python
import niquests


def pizza_auth(request: niquests.PreparedRequest) -> niquests.PreparedRequest:
    if request.headers:
        request.headers["X-Pizza"] = "Token"
    return request


def test_callable_auth():
    r = niquests.get("https://httpbin.org/get", auth=pizza_auth)
    print(r.json()["headers"])


if __name__ == "__main__":
    test_callable_auth()
```

</details>

This is allowed at runtime.

https://github.com/jawah/niquests/blob/d83ab6b98e317bbf82ea950a693fce1fc95936a3/src/niquests/models.py#L615-L647