### PR TITLE
:bookmark: Release 3.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/|noxfile.py'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.7.904', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.9.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,20 @@
 Release History
 ===============
 
+3.8.0 (2024-09-24)
+------------------
+
+**Added**
+- Support for HTTP Trailers.
+- Help script now yield warnings if update are available for each sub dependencies.
+
+**Fixed**
+- Setting a list of Resolver.
+
+**Changed**
+- urllib3-future lower bound version is raised to 2.9.900 (for http trailer support).
+- relax strict kwargs passing in Session adapters (required for some plugins).
+
 3.7.2 (2024-07-09)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -12,34 +12,36 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 <details>
   <summary>👆 <b>Look at the feature table comparison</b> against <i>requests, httpx and aiohttp</i>!</summary>
 
-| Feature                                                                  |         niquests          |              requests              |             httpx             | aiohttp              |
-|--------------------------------------------------------------------------|:-------------------------:|:----------------------------------:|:-----------------------------:|----------------------|
-| `HTTP/1.1`                                                               |             ✅             |                 ✅                  |               ✅               | ✅                    |
-| `HTTP/2`                                                                 |             ✅             |                 ❌                  |             ✅[^7]             | ❌                    |
-| `HTTP/3 over QUIC`                                                       |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `Synchronous`                                                            |             ✅             |                 ✅                  |               ✅               | ❌                    |
-| `Asynchronous`                                                           |             ✅             |                 ❌                  |               ✅               | ✅                    |
-| `Thread Safe`                                                            |             ✅             |                 ✅                  |             ❌[^5]             | _N/A_[^1]            |
-| `Task Safe`                                                              |             ✅             |             _N/A_[^2]              |               ✅               | ✅                    |
-| `OS Trust Store`                                                         |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `Multiplexing`                                                           |             ✅             |                 ❌                  |         _Limited_[^3]         | ❌                    |
-| `DNSSEC`                                                                 |          ✅[^11]           |                 ❌                  |               ❌               | ❌                    |
-| `Customizable DNS Resolution`                                            |             ✅             |                 ❌                  |               ❌               | ✅                    |
-| `DNS over HTTPS`                                                         |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `DNS over QUIC`                                                          |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `DNS over TLS`                                                           |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `Multiple DNS Resolver`                                                  |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `Network Fine Tuning & Inspect`                                          |             ✅             |                 ❌                  |         _Limited_[^6]         | _Limited_[^6]        |
-| `Certificate Revocation Protection`                                      |             ✅             |                 ❌                  |               ❌               | ❌                    |
-| `Session Persistence`                                                    |             ✅             |                 ✅                  |               ✅               | ✅                    |
-| `In-memory Certificate CA & mTLS`                                        |             ✅             |                 ❌                  |         _Limited_[^4]         | _Limited_[^4]        |
-| `SOCKS 4/5 Proxies`                                                      |             ✅             |                 ✅                  |               ✅               | ❌                    |
-| `HTTP/HTTPS Proxies`                                                     |             ✅             |                 ✅                  |               ✅               | ✅                    |
-| `TLS-in-TLS Support`                                                     |             ✅             |                 ✅                  |               ✅               | ✅                    |
-| `Direct HTTP/3 Negotiation`                                              |           ✅[^9]           |              N/A[^8]               |            N/A[^8]            | N/A[^8]              |
-| `Happy Eyeballs`                                                         |             ✅             |                 ❌                  |               ❌               | ✅                    |
-| `Package / SLSA Signed`                                                  |             ✅             |                 ❌                  |               ❌               | ✅                    |
-| `HTTP/2 with prior knowledge (h2c)`                                      |             ✅             |                 ❌                  |               ✅               | ❌                    |
+| Feature                             |    niquests    | requests  |     httpx     | aiohttp       |
+|-------------------------------------|:--------------:|:---------:|:-------------:|---------------|
+| `HTTP/1.1`                          |       ✅        |     ✅     |       ✅       | ✅             |
+| `HTTP/2`                            |       ✅        |     ❌     |     ✅[^7]     | ❌             |
+| `HTTP/3 over QUIC`                  |       ✅        |     ❌     |       ❌       | ❌             |
+| `Synchronous`                       |       ✅        |     ✅     |       ✅       | ❌             |
+| `Asynchronous`                      |       ✅        |     ❌     |       ✅       | ✅             |
+| `Thread Safe`                       |       ✅        |     ✅     |     ❌[^5]     | _N/A_[^1]     |
+| `Task Safe`                         |       ✅        | _N/A_[^2] |       ✅       | ✅             |
+| `OS Trust Store`                    |       ✅        |     ❌     |       ❌       | ❌             |
+| `Multiplexing`                      |       ✅        |     ❌     | _Limited_[^3] | ❌             |
+| `DNSSEC`                            |     ✅[^11]     |     ❌     |       ❌       | ❌             |
+| `Customizable DNS Resolution`       |       ✅        |     ❌     |       ❌       | ✅             |
+| `DNS over HTTPS`                    |       ✅        |     ❌     |       ❌       | ❌             |
+| `DNS over QUIC`                     |       ✅        |     ❌     |       ❌       | ❌             |
+| `DNS over TLS`                      |       ✅        |     ❌     |       ❌       | ❌             |
+| `Multiple DNS Resolver`             |       ✅        |     ❌     |       ❌       | ❌             |
+| `Network Fine Tuning & Inspect`     |       ✅        |     ❌     | _Limited_[^6] | _Limited_[^6] |
+| `Certificate Revocation Protection` |       ✅        |     ❌     |       ❌       | ❌             |
+| `Session Persistence`               |       ✅        |     ✅     |       ✅       | ✅             |
+| `In-memory Certificate CA & mTLS`   |       ✅        |     ❌     | _Limited_[^4] | _Limited_[^4] |
+| `SOCKS 4/5 Proxies`                 |       ✅        |     ✅     |       ✅       | ❌             |
+| `HTTP/HTTPS Proxies`                |       ✅        |     ✅     |       ✅       | ✅             |
+| `TLS-in-TLS Support`                |       ✅        |     ✅     |       ✅       | ✅             |
+| `Direct HTTP/3 Negotiation`         |     ✅[^9]      |  N/A[^8]  |    N/A[^8]    | N/A[^8]       |
+| `Happy Eyeballs`                    |       ✅        |     ❌     |       ❌       | ✅             |
+| `Package / SLSA Signed`             |       ✅        |     ❌     |       ❌       | ✅             |
+| `HTTP/2 with prior knowledge (h2c)` |       ✅        |     ❌     |       ✅       | ❌             |
+| `Post-Quantum Security`             | _Limited_[^12] |     ❌     |       ❌       | ❌             |
+| `HTTP Trailers`                     |       ✅        |     ❌     |       ❌       | ❌             |
 </details>
 
 <details>
@@ -148,6 +150,7 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - HTTP/2 with prior knowledge
 - Object-oriented headers
 - Multi-part File Uploads
+- Post-Quantum Security
 - Chunked HTTP Requests
 - Fully type-annotated!
 - SOCKS Proxy Support
@@ -158,6 +161,7 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
+- Trailers!
 - DNSSEC!
 - Async!
 
@@ -198,3 +202,4 @@ Niquests is a highly improved HTTP client that is based (forked) on Requests. Th
 [^9]: you must use a custom DNS resolver so that it can preemptively connect using HTTP/3 over QUIC when remote is compatible.
 [^10]: performance measured when leveraging a multiplexed connection with or without uses of any form of concurrency as of July 2024. The research compared `httpx`, `requests`, `aiohttp` against `niquests`. See https://github.com/Ousret/niquests-stats
 [^11]: enabled when using a custom DNS resolver.
+[^12]: available only when using HTTP/3 over QUIC and that the remote server support also the same post-quantum key-exchange algorithm. Also, the `qh3` installed version must be >= 1.1.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,7 @@ Niquests is ready for today's web.
 - Familiar `dict`–like Cookies
 - Object-oriented headers
 - Multi-part File Uploads
+- Post-Quantum Security
 - Chunked HTTP Requests
 - Fully type-annotated!
 - SOCKS Proxy Support
@@ -88,6 +89,7 @@ Niquests is ready for today's web.
 - Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
+- Trailers!
 - DNSSEC!
 - Async!
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1485,3 +1485,25 @@ Here is a basic example of how you would proceed::
             for chunk in r.iter_content():
                 # do anything you want with chunk
                 print(r.download_progress.total)  # this actually contain the amt of bytes (raw) downloaded from the socket.
+
+
+HTTP Trailers
+-------------
+
+.. note:: Available since Niquests 3.8+
+
+HTTP response may contain one or several trailer headers. Those special headers are received
+after the reception of the body. Before this, those headers were unreachable and dropped silently.
+
+Quoted from Mozilla MDN: "The Trailer response header allows the sender to include additional fields
+at the end of chunked messages in order to supply metadata that might be dynamically generated while the
+message body is sent, such as a message integrity check, digital signature, or post-processing status."
+
+For example, we retrieve our trailers this way::
+
+    >>> url = 'https://httpbingo.org/trailers?foo=baz'
+    >>> r = niquests.get(url)
+    >>> r.trailers  # output: {'foo': 'baz'}
+
+
+.. warning:: The ``trailers`` property is only filled when the response has been consumed entirely. The server only send them after finishing sending the body. By default, ``trailers`` is an empty CaseInsensibleDict.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.8.902,<3",
+    "urllib3.future>=2.9.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.7.2"
+__version__ = "3.8.0"
 
-__build__: int = 0x030702
+__build__: int = 0x030800
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1200,15 +1200,24 @@ class Session:
             # Send the request
             r = adapter.send(request, **kwargs)
         except TypeError:
-            # this is required because some people may do an incomplete migration.
-            # this will hint them appropriately.
-            raise TypeError(
-                "You probably tried to add a Requests adapter into a Niquests session. "
-                "Make sure you replaced the 'import requests.adapters' into 'import niquests.adapters' "
-                "and made required adjustment. If you did this to increase pool_maxsize, know that the "
-                "Session constructor support kwargs for it. "
-                "See https://niquests.readthedocs.io/en/latest/user/quickstart.html#scale-your-session-pool to learn more."
-            )
+            if "requests." in str(type(adapter)):
+                # this is required because some people may do an incomplete migration.
+                # this will hint them appropriately.
+                raise TypeError(
+                    "You probably tried to add a Requests adapter into a Niquests session. "
+                    "Make sure you replaced the 'import requests.adapters' into 'import niquests.adapters' "
+                    "and made required adjustment. If you did this to increase pool_maxsize, know that the "
+                    "Session constructor support kwargs for it. "
+                    "See https://niquests.readthedocs.io/en/latest/user/quickstart.html#scale-your-session-pool to learn more."
+                )
+            else:
+                # probably using a plugin that don't support extra kwargs!
+                # try nonetheless!
+                del kwargs["multiplexed"]
+                del kwargs["on_upload_body"]
+                del kwargs["on_post_connection"]
+
+                r = adapter.send(request, **kwargs)
 
         # Make sure the timings data are kept as is, conn_info is a reference to
         # urllib3-future conn_info.

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -1013,6 +1013,13 @@ def create_resolver(definition: ResolverType | None) -> BaseResolver:
         resolver = [ResolverDescription.from_url(definition)]
     elif isinstance(definition, ResolverDescription):
         resolver = [definition]
+    elif isinstance(definition, list):
+        if not definition:
+            return ResolverDescription(ProtocolResolver.SYSTEM).new()
+        if isinstance(definition[0], str):
+            resolver = [ResolverDescription.from_url(e) for e in definition]  # type: ignore[arg-type]
+        else:
+            resolver = definition  # type: ignore[assignment]
     else:
         raise ValueError("invalid resolver definition given")
 
@@ -1076,6 +1083,13 @@ def create_async_resolver(definition: AsyncResolverType | None) -> AsyncBaseReso
         resolver = [AsyncResolverDescription.from_url(definition)]
     elif isinstance(definition, AsyncResolverDescription):
         resolver = [definition]
+    elif isinstance(definition, list):  # can either be list of str or list of Resolver
+        if not definition:
+            return AsyncResolverDescription(ProtocolResolver.SYSTEM).new()
+        if isinstance(definition[0], str):
+            resolver = [AsyncResolverDescription.from_url(e) for e in definition]  # type: ignore[arg-type]
+        else:
+            resolver = definition  # type: ignore[assignment]
     else:
         raise ValueError("invalid resolver definition given")
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -89,6 +89,29 @@ class TestAsyncWithoutMultiplex:
             assert r.status_code == 200
             assert "X-Async-Auth" in r.json()["headers"]
 
+    # async def test_http_trailer_preload(self) -> None:
+    #     async with AsyncSession() as s:
+    #         r = await s.get("https://httpbingo.org/trailers?foo=baz")
+    #
+    #         assert r.ok
+    #         assert r.trailers
+    #         assert "foo" in r.trailers
+    #         assert r.trailers["foo"] == "baz"
+    #
+    # async def test_http_trailer_no_preload(self) -> None:
+    #     async with AsyncSession() as s:
+    #         r = await s.get("https://httpbingo.org/trailers?foo=baz", stream=True)
+    #
+    #         assert r.ok
+    #         assert not r.trailers
+    #         assert "foo" not in r.trailers
+    #
+    #         await r.content
+    #
+    #         assert r.trailers
+    #         assert "foo" in r.trailers
+    #         assert r.trailers["foo"] == "baz"
+
 
 @pytest.mark.usefixtures("requires_wan")
 @pytest.mark.asyncio

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -110,3 +110,26 @@ class TestLiveStandardCase:
             r = s.get("https://pie.dev/get")
 
             assert r.ok
+
+    # def test_http_trailer_preload(self) -> None:
+    #     with Session() as s:
+    #         r = s.get("https://httpbingo.org/trailers?foo=baz")
+    #
+    #         assert r.ok
+    #         assert r.trailers
+    #         assert "foo" in r.trailers
+    #         assert r.trailers["foo"] == "baz"
+    #
+    # def test_http_trailer_no_preload(self) -> None:
+    #     with Session() as s:
+    #         r = s.get("https://httpbingo.org/trailers?foo=baz", stream=True)
+    #
+    #         assert r.ok
+    #         assert not r.trailers
+    #         assert "foo" not in r.trailers
+    #
+    #         r.content
+    #
+    #         assert r.trailers
+    #         assert "foo" in r.trailers
+    #         assert r.trailers["foo"] == "baz"


### PR DESCRIPTION
**Added**
- Support for HTTP Trailers.
- Help script now yield warnings if update are available for each sub dependencies.

**Fixed**
- Setting a list of Resolver.

**Changed**
- urllib3-future lower bound version is raised to 2.9.900 (for http trailer support).
- relax strict kwargs passing in Session adapters (required for some plugins).