### PR TITLE
:bookmark: Release 3.9.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-latest, macOS-13, windows-latest]
         include:
           # pypy-3.7, pypy-3.8 may fail due to missing cryptography wheels. Adapting.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,9 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
+  rev: v1.11.2
   hooks:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/|noxfile.py'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.9.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.10.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,20 @@
 Release History
 ===============
 
+3.9.0 (2024-10-08)
+------------------
+
+**Added**
+- Support for WebSocket over HTTP/1, HTTP/2 and HTTP/3. It brings a unified API that makes you leverage
+  our powerful features like Happy Eyeballs, SOCKS/HTTP/HTTPS proxies, thread/task safety etc...
+- Hook for catching early responses like "103 Early Hints".
+
+**Fixed**
+- Informational responses are fully supported over HTTP/1, HTTP/2 and HTTP/3.
+
+**Changed**
+- urllib3-future lower bound version is raised to 2.10.900.
+
 3.8.0 (2024-09-24)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `HTTP/1.1`                          |       ✅        |     ✅     |       ✅       | ✅             |
 | `HTTP/2`                            |       ✅        |     ❌     |     ✅[^7]     | ❌             |
 | `HTTP/3 over QUIC`                  |       ✅        |     ❌     |       ❌       | ❌             |
-| `Synchronous`                       |       ✅        |     ✅     |       ✅       | ❌             |
+| `Synchronous`                       |       ✅        |     ✅     |       ✅       | _N/A_[^1]     |
 | `Asynchronous`                      |       ✅        |     ❌     |       ✅       | ✅             |
 | `Thread Safe`                       |       ✅        |     ✅     |     ❌[^5]     | _N/A_[^1]     |
 | `Task Safe`                         |       ✅        | _N/A_[^2] |       ✅       | ✅             |
@@ -42,6 +42,9 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `HTTP/2 with prior knowledge (h2c)` |       ✅        |     ❌     |       ✅       | ❌             |
 | `Post-Quantum Security`             | _Limited_[^12] |     ❌     |       ❌       | ❌             |
 | `HTTP Trailers`                     |       ✅        |     ❌     |       ❌       | ❌             |
+| `Early Responses`                   |       ✅        |     ❌     |       ❌       | ❌             |
+| `WebSocket over HTTP/1`             |       ✅        |  ❌[^14]   |    ❌[^14]     | ❌[^14]        |
+| `WebSocket over HTTP/2 and HTTP/3`  |     ✅[^13]     |     ❌     |       ❌       | ❌             |
 </details>
 
 <details>
@@ -158,9 +161,11 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Early Responses
 - Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
+- WebSocket!
 - Trailers!
 - DNSSEC!
 - Async!
@@ -191,15 +196,17 @@ You may also be interested in unlocking specific advantages _(like access to a p
 
 Niquests is a highly improved HTTP client that is based (forked) on Requests. The previous project original author is Kenneth Reitz and actually left the maintenance of Requests years ago.
 
-[^1]: aiohttp has no support for synchronous request.
+[^1]: aiohttp was conceived solely for an asynchronous context.
 [^2]: requests has no support for asynchronous request.
 [^3]: while the HTTP/2 connection object can handle concurrent requests, you cannot leverage its true potential.
 [^4]: loading client certificate without file can't be done.
 [^5]: httpx officially claim to be thread safe but recent tests demonstrate otherwise as of february 2024. https://github.com/jawah/niquests/issues/83#issuecomment-1956065258 https://github.com/encode/httpx/issues/3072 https://github.com/encode/httpx/issues/3002
 [^6]: they do not expose anything to control network aspects such as IPv4/IPv6 toggles, and timings (e.g. DNS response time, established delay, TLS handshake delay, etc...) and such.
-[^7]: while advertised as possible, they refuse to make it the default due to performance issues. as of february 2024 an extra is required to enable it manually.
+[^7]: while advertised as possible, they refuse to make it the default due to performance issues. as of October 2024 an extra is required to enable it manually.
 [^8]: they don't support HTTP/3 at all.
 [^9]: you must use a custom DNS resolver so that it can preemptively connect using HTTP/3 over QUIC when remote is compatible.
-[^10]: performance measured when leveraging a multiplexed connection with or without uses of any form of concurrency as of July 2024. The research compared `httpx`, `requests`, `aiohttp` against `niquests`. See https://github.com/Ousret/niquests-stats
+[^10]: performance measured when leveraging a multiplexed connection with or without uses of any form of concurrency as of October 2024. The research compared `httpx`, `requests`, `aiohttp` against `niquests`. See https://github.com/Ousret/niquests-stats
 [^11]: enabled when using a custom DNS resolver.
 [^12]: available only when using HTTP/3 over QUIC and that the remote server support also the same post-quantum key-exchange algorithm. Also, the `qh3` installed version must be >= 1.1.
+[^13]: most servers out there are not ready for this feature, but Niquests is already compliant and future-proof! Modern server like Caddy are still working on it, see https://github.com/caddyserver/caddy/pull/6567 for more.
+[^14]: they don't offer any built-in to speak with a WebSocket server.

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -140,7 +140,7 @@ Ever encountered something along::
 Yes? Usually it means that you tried to load a certificate (CA or client cert) that is malformed.
 
 What does malformed means?
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Could be just a missing newline character *RC*, or wrong format like passing a DER file instead of a PEM
 encoded certificate.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,9 +86,11 @@ Niquests is ready for today's web.
 - Streaming Downloads
 - HTTP/2 by default
 - HTTP/3 over QUIC
+- Early Responses
 - Happy Eyeballs
 - Multiplexed!
 - Thread-safe!
+- WebSocket!
 - Trailers!
 - DNSSEC!
 - Async!

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import nox
 
 def tests_impl(
     session: nox.Session,
-    extras: str = "socks",
+    extras: str = "socks,ws",
     cohabitation: bool | None = False,
 ) -> None:
     # Install deps and the package itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.9.900,<3",
+    "urllib3.future>=2.10.900,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]
@@ -56,6 +56,9 @@ http3 = [
 ]
 ocsp = [
     "urllib3.future[qh3]",
+]
+ws = [
+    "urllib3.future[ws]",
 ]
 speedups = [
     "orjson>=3,<4",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -e .[socks]
 pytest>=2.8.0,<=7.4.4
 pytest-cov
-pytest-httpbin==2.0.0
+pytest-httpbin>=2,<3
 pytest-asyncio>=0.21.1,<1.0
 httpbin==0.10.2
 trustme

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.8.0"
+__version__ = "3.9.0"
 
-__build__: int = 0x030800
+__build__: int = 0x030900
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -405,7 +405,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
             cookie.value = cookie.value.replace('\\"', "")
         return super().set_cookie(cookie, *args, **kwargs)
 
-    def update(self, other):
+    def update(self, other):  # type: ignore[override]
         """Updates this jar with cookies from another CookieJar or dict-like"""
         if isinstance(other, cookielib.CookieJar):
             for cookie in other:

--- a/src/niquests/hooks.py
+++ b/src/niquests/hooks.py
@@ -34,6 +34,7 @@ HOOKS = [
     "pre_request",
     "pre_send",
     "on_upload",
+    "early_response",
     "response",
 ]
 

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -54,6 +54,8 @@ if HAS_LEGACY_URLLIB3 is False:
     from urllib3.fields import RequestField
     from urllib3.filepost import choose_boundary, encode_multipart_formdata
     from urllib3.util import parse_url
+    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP
+    from urllib3.contrib.webextensions import ExtensionFromHTTP
 else:
     from urllib3_future import (  # type: ignore[assignment]
         BaseHTTPResponse,
@@ -71,6 +73,8 @@ else:
     from urllib3_future.fields import RequestField  # type: ignore[assignment]
     from urllib3_future.filepost import choose_boundary, encode_multipart_formdata  # type: ignore[assignment]
     from urllib3_future.util import parse_url  # type: ignore[assignment]
+    from urllib3_future.contrib.webextensions._async import AsyncExtensionFromHTTP  # type: ignore[assignment]
+    from urllib3_future.contrib.webextensions import ExtensionFromHTTP  # type: ignore[assignment]
 
 from ._typing import (
     BodyFormType,
@@ -1019,6 +1023,15 @@ class Response:
         self.download_progress: TransferProgress | None = None
 
     @property
+    def extension(self) -> ExtensionFromHTTP | None:
+        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler."""
+        return (
+            self.raw.extension
+            if self.raw is not None and hasattr(self.raw, "extension")
+            else None
+        )
+
+    @property
     def lazy(self) -> bool:
         """
         Determine if response isn't received and is actually a placeholder.
@@ -1597,6 +1610,15 @@ class AsyncResponse(Response):
         "cookies",
         "elapsed",
     }
+
+    @property
+    def extension(self) -> AsyncExtensionFromHTTP | None:  # type: ignore[override]
+        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler."""
+        return (
+            self.raw.extension
+            if self.raw is not None and hasattr(self.raw, "extension")
+            else None
+        )
 
     def __aenter__(self) -> AsyncResponse:
         return self

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -89,6 +89,23 @@ class TestAsyncWithoutMultiplex:
             assert r.status_code == 200
             assert "X-Async-Auth" in r.json()["headers"]
 
+    async def test_early_response(self) -> None:
+        received_early_response: bool = False
+
+        async def callback_on_early(early_resp) -> None:
+            nonlocal received_early_response
+            if early_resp.status_code == 103:
+                received_early_response = True
+
+        async with AsyncSession() as s:
+            resp = await s.get(
+                "https://early-hints.fastlylabs.com/",
+                hooks={"early_response": [callback_on_early]},
+            )
+
+            assert resp.status_code == 200
+            assert received_early_response is True
+
     # async def test_http_trailer_preload(self) -> None:
     #     async with AsyncSession() as s:
     #         r = await s.get("https://httpbingo.org/trailers?foo=baz")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -41,5 +41,6 @@ def test_default_hooks():
         "pre_request": [],
         "pre_send": [],
         "on_upload": [],
+        "early_response": [],
         "response": [],
     }

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -113,7 +113,7 @@ class TestLiveStandardCase:
 
     # def test_http_trailer_preload(self) -> None:
     #     with Session() as s:
-    #         r = s.get("https://httpbingo.org/trailers?foo=baz")
+    #         r = s.get("https://httpbingo.org/trailers?foo=baz", headers={"TE": "trailers"})
     #
     #         assert r.ok
     #         assert r.trailers
@@ -122,7 +122,7 @@ class TestLiveStandardCase:
     #
     # def test_http_trailer_no_preload(self) -> None:
     #     with Session() as s:
-    #         r = s.get("https://httpbingo.org/trailers?foo=baz", stream=True)
+    #         r = s.get("https://httpbingo.org/trailers?foo=baz", headers={"TE": "trailers"}, stream=True)
     #
     #         assert r.ok
     #         assert not r.trailers
@@ -133,3 +133,20 @@ class TestLiveStandardCase:
     #         assert r.trailers
     #         assert "foo" in r.trailers
     #         assert r.trailers["foo"] == "baz"
+
+    def test_early_response(self) -> None:
+        received_early_response: bool = False
+
+        def callback_on_early(early_resp) -> None:
+            nonlocal received_early_response
+            if early_resp.status_code == 103:
+                received_early_response = True
+
+        with Session() as s:
+            resp = s.get(
+                "https://early-hints.fastlylabs.com/",
+                hooks={"early_response": [callback_on_early]},
+            )
+
+            assert resp.status_code == 200
+            assert received_early_response is True

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import sys
 import threading
 from json import JSONDecodeError
@@ -125,13 +124,12 @@ def test_conflicting_content_lengths():
 
 
 @pytest.mark.xfail(
-    platform.python_implementation() == "PyPy"
-    and sys.version_info
+    sys.version_info
     < (
         3,
         8,
     ),
-    reason="PyPy 3.7 bug with socket unexpected close server side",
+    reason="Bug with socket unexpected close server side",
 )
 def test_digestauth_401_count_reset_on_redirect():
     """Ensure we correctly reset num_401_calls after a successful digest auth,
@@ -200,13 +198,12 @@ def test_digestauth_401_count_reset_on_redirect():
 
 
 @pytest.mark.xfail(
-    platform.python_implementation() == "PyPy"
-    and sys.version_info
+    sys.version_info
     < (
         3,
         8,
     ),
-    reason="PyPy 3.7 bug with socket unexpected close server side",
+    reason="Bug with socket unexpected close server side",
 )
 def test_digestauth_401_only_sent_once():
     """Ensure we correctly respond to a 401 challenge once, and then
@@ -331,13 +328,12 @@ def test_use_proxy_from_environment(httpbin, var, scheme):
 
 
 @pytest.mark.xfail(
-    platform.python_implementation() == "PyPy"
-    and sys.version_info
+    sys.version_info
     < (
         3,
         8,
     ),
-    reason="PyPy 3.7 bug with socket unexpected close server side",
+    reason="Bug with socket unexpected close server side",
 )
 def test_redirect_rfc1808_to_non_ascii_location():
     path = "š"
@@ -397,13 +393,12 @@ def test_fragment_not_sent_with_request():
 
 
 @pytest.mark.xfail(
-    platform.python_implementation() == "PyPy"
-    and sys.version_info
+    sys.version_info
     < (
         3,
         8,
     ),
-    reason="PyPy 3.7 bug with socket unexpected close server side",
+    reason="Bug with socket unexpected close server side",
 )
 def test_fragment_update_on_redirect():
     """Verify we only append previous fragment if one doesn't exist on new

--- a/tests/test_ocsp.py
+++ b/tests/test_ocsp.py
@@ -3,10 +3,16 @@ import pytest
 from niquests import Session, AsyncSession
 from niquests.exceptions import ConnectionError, Timeout
 
+try:
+    import qh3
+except ImportError:
+    qh3 = None
+
 OCSP_MAX_DELAY_WAIT = 5
 
 
 @pytest.mark.usefixtures("requires_wan")
+@pytest.mark.skipif(qh3 is None, reason="qh3 unavailable")
 class TestOnlineCertificateRevocationProtocol:
     """This test class hold the minimal amount of confidence
     we need to ensure revoked certificate are properly rejected.
@@ -16,9 +22,9 @@ class TestOnlineCertificateRevocationProtocol:
     @pytest.mark.parametrize(
         "revoked_peer_url",
         [
-            "https://revoked.badssl.com/",
+            # "https://revoked.badssl.com/",
             # "https://revoked-rsa-ev.ssl.com/",
-            # "https://revoked-ecc-dv.ssl.com/",
+            "https://revoked-ecc-dv.ssl.com/",
         ],
     )
     def test_sync_revoked_certificate(self, revoked_peer_url: str) -> None:
@@ -40,9 +46,9 @@ class TestOnlineCertificateRevocationProtocol:
     @pytest.mark.parametrize(
         "revoked_peer_url",
         [
-            "https://revoked.badssl.com/",
+            # "https://revoked.badssl.com/",
             # "https://revoked-rsa-ev.ssl.com/",
-            # "https://revoked-ecc-dv.ssl.com/",
+            "https://revoked-ecc-dv.ssl.com/",
         ],
     )
     async def test_async_revoked_certificate(self, revoked_peer_url: str) -> None:

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from niquests import Session, AsyncSession
+
+try:
+    import wsproto
+except ImportError:
+    wsproto = None
+
+
+@pytest.mark.usefixtures("requires_wan")
+@pytest.mark.skipif(wsproto is None, reason="wsproto unavailable")
+class TestLiveWebSocket:
+    def test_sync_websocket_basic_example(self) -> None:
+        with Session() as s:
+            resp = s.get("wss://echo.websocket.org")
+
+            assert resp.status_code == 101
+            assert resp.extension is not None
+            assert resp.extension.closed is False
+
+            greeting_msg = resp.extension.next_payload()
+
+            assert greeting_msg is not None
+            assert isinstance(greeting_msg, str)
+
+            resp.extension.send_payload("Hello World")
+            resp.extension.send_payload(b"Foo Bar Baz!")
+
+            assert resp.extension.next_payload() == "Hello World"
+            assert resp.extension.next_payload() == b"Foo Bar Baz!"
+
+            resp.extension.close()
+            assert resp.extension.closed is True
+
+    @pytest.mark.asyncio
+    async def test_async_websocket_basic_example(self) -> None:
+        async with AsyncSession() as s:
+            resp = await s.get("wss://echo.websocket.org")
+
+            assert resp.status_code == 101
+            assert resp.extension is not None
+            assert resp.extension.closed is False
+
+            greeting_msg = await resp.extension.next_payload()
+
+            assert greeting_msg is not None
+            assert isinstance(greeting_msg, str)
+
+            await resp.extension.send_payload("Hello World")
+            await resp.extension.send_payload(b"Foo Bar Baz!")
+
+            assert (await resp.extension.next_payload()) == "Hello World"
+            assert (await resp.extension.next_payload()) == b"Foo Bar Baz!"
+
+            await resp.extension.close()
+            assert resp.extension.closed is True


### PR DESCRIPTION
**Added**
- Support for WebSocket over HTTP/1, HTTP/2 and HTTP/3. It brings a unified API that makes you leverage our powerful features like Happy Eyeballs, SOCKS/HTTP/HTTPS proxies, thread/task safety etc...
- Hook for catching early responses like "103 Early Hints".

**Fixed**
- Informational responses are fully supported over HTTP/1, HTTP/2 and HTTP/3.

**Changed**
- urllib3-future lower bound version is raised to 2.10.900.