### PR TITLE
Fix aiohttp feature comparison in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 | `Post-Quantum Security`             | _Limited_[^12] |     ❌     |       ❌       | ❌             |
 | `HTTP Trailers`                     |       ✅        |     ❌     |       ❌       | ❌             |
 | `Early Responses`                   |       ✅        |     ❌     |       ❌       | ❌             |
-| `WebSocket over HTTP/1`             |       ✅        |  ❌[^14]   |    ❌[^14]     | ❌[^14]        |
+| `WebSocket over HTTP/1`             |       ✅        |  ❌[^14]   |    ❌[^14]     | ✅             |
 | `WebSocket over HTTP/2 and HTTP/3`  |     ✅[^13]     |     ❌     |       ❌       | ❌             |
 </details>
 


### PR DESCRIPTION
I'm very excited about the new WebSocket support in niquests! Just to clarify, though, aiohttp is already a powerful WebSocket (HTTP/1.1) client:
https://docs.aiohttp.org/en/stable/client_quickstart.html#websockets