### PR TITLE
Release 3.9.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,13 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
-        os: [ubuntu-latest, macOS-13, windows-latest]
+        os: [ubuntu-22.04, macOS-13, windows-latest]
         include:
           # pypy-3.7, pypy-3.8 may fail due to missing cryptography wheels. Adapting.
           - python-version: pypy-3.7
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - python-version: pypy-3.8
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - python-version: pypy-3.8
             os: macOS-13
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/|noxfile.py'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.10.900', 'wassima>=1.0.1', 'idna', 'kiss_headers']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.10.903', 'wassima>=1.0.1', 'idna', 'kiss_headers']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,22 @@
 Release History
 ===============
 
+3.9.1 (2024-10-13)
+------------------
+
+**Fixed**
+- Exception leak from urllib3-future when using WebSocket.
+- Enforcing HTTP/3 in an AsyncSession. (#152)
+- Adapter kwargs fallback to support old Requests extensions.
+- Type hint for ``Response.extension`` linked to the generic interface instead of the inherited ones.
+- Accessing WS over HTTP/2+ using the synchronous session object.
+
+**Misc**
+- Documentation improvement for in-memory certificates and WebSocket use cases.
+
+**Changed**
+- urllib3-future lower bound version is raised to 2.10.904 to ensure exception are properly translated into urllib3-future ones for WS.
+
 3.9.0 (2024-10-08)
 ------------------
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -313,6 +313,10 @@ In-memory Certificates
 The ``cert=...`` and ``verify=...`` can actually take the certificates themselves. Niquests support
 in-memory certificates instead of file paths.
 
+.. warning:: The mTLS (aka. ``cert=...``) using in-memory certificate only works with Linux, FreeBSD or OpenBSD. See https://urllib3future.readthedocs.io/en/latest/advanced-usage.html#in-memory-client-mtls-certificate for more. It works on all platforms if you are using HTTP/3 over QUIC.
+
+.. note:: When leveraging in-memory certificate for mTLS (aka. ``cert=...``), you have two possible configurations: (cert, key) or (cert, key, password) you cannot pass (cert) having concatenated cert,key in a single string.
+
 .. _ca-certificates:
 
 CA Certificates
@@ -320,7 +324,8 @@ CA Certificates
 
 Niquests uses certificates provided by the package `wassima`_. This allows for users
 to not care about root CAs. By default it is expected to use your operating system root CAs.
-You have nothing to do.
+You have nothing to do. If we were unable to access your OS truststore natively, (e.g. not Windows, not MacOS, not Linux), then
+we will fallback on the ``certifi`` bundle.
 
 .. _HTTP persistent connection: https://en.wikipedia.org/wiki/HTTP_persistent_connection
 .. _connection pooling: https://urllib3.readthedocs.io/en/latest/reference/index.html#module-urllib3.connectionpool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = ["version"]
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3.future>=2.10.900,<3",
+    "urllib3.future>=2.10.904,<3",
     "wassima>=1.0.1,<2",
     "kiss_headers>=2,<4",
 ]

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.9.0"
+__version__ = "3.9.1"
 
-__build__: int = 0x030900
+__build__: int = 0x030901
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -243,6 +243,7 @@ class AsyncSession(Session):
             AsyncHTTPAdapter(
                 quic_cache_layer=self.quic_cache_layer,
                 max_retries=retries,
+                disable_http1=disable_http1,
                 disable_http2=disable_http2,
                 disable_http3=disable_http3,
                 resolver=resolver,
@@ -258,6 +259,9 @@ class AsyncSession(Session):
             "http://",
             AsyncHTTPAdapter(
                 max_retries=retries,
+                disable_http1=disable_http1,
+                disable_http2=disable_http2,
+                disable_http3=disable_http3,
                 resolver=resolver,
                 source_address=source_address,
                 disable_ipv4=disable_ipv4,
@@ -422,6 +426,7 @@ class AsyncSession(Session):
                 AsyncHTTPAdapter(
                     quic_cache_layer=self.quic_cache_layer,
                     max_retries=self.retries,
+                    disable_http1=self._disable_http1,
                     disable_http2=self._disable_http2,
                     disable_http3=self._disable_http3,
                     resolver=self.resolver,
@@ -437,6 +442,9 @@ class AsyncSession(Session):
                 "http://",
                 AsyncHTTPAdapter(
                     max_retries=self.retries,
+                    disable_http1=self._disable_http1,
+                    disable_http2=self._disable_http2,
+                    disable_http3=self._disable_http3,
                     resolver=self.resolver,
                     source_address=self.source_address,
                     disable_ipv4=self._disable_ipv4,

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -913,7 +913,14 @@ class HTTPAdapter(BaseAdapter):
         extension = None
 
         if scheme is not None and scheme not in ("http", "https"):
-            extension = load_extension(scheme)()
+            if "+" in scheme:
+                scheme, implementation = tuple(scheme.split("+", maxsplit=1))
+            else:
+                implementation = None
+
+            extension = wrap_extension_for_http(
+                load_extension(scheme, implementation=implementation)
+            )()
 
         def early_response_hook(early_response: BaseHTTPResponse) -> None:
             nonlocal on_early_response

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -161,6 +161,8 @@ from .utils import (
     _deepcopy_ci,
     parse_scheme,
     is_ocsp_capable,
+    wrap_extension_for_http,
+    async_wrap_extension_for_http,
 )
 
 try:
@@ -1916,7 +1918,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             else:
                 implementation = None
 
-            extension = async_load_extension(scheme, implementation=implementation)()
+            extension = async_wrap_extension_for_http(
+                async_load_extension(scheme, implementation=implementation)
+            )()
 
         async def early_response_hook(early_response: BaseAsyncHTTPResponse) -> None:
             nonlocal on_early_response

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -54,8 +54,14 @@ if HAS_LEGACY_URLLIB3 is False:
     from urllib3.fields import RequestField
     from urllib3.filepost import choose_boundary, encode_multipart_formdata
     from urllib3.util import parse_url
-    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP
-    from urllib3.contrib.webextensions import ExtensionFromHTTP
+    from urllib3.contrib.webextensions._async import (
+        AsyncWebSocketExtensionFromHTTP,
+        AsyncRawExtensionFromHTTP,
+    )
+    from urllib3.contrib.webextensions import (
+        WebSocketExtensionFromHTTP,
+        RawExtensionFromHTTP,
+    )
 else:
     from urllib3_future import (  # type: ignore[assignment]
         BaseHTTPResponse,
@@ -73,8 +79,14 @@ else:
     from urllib3_future.fields import RequestField  # type: ignore[assignment]
     from urllib3_future.filepost import choose_boundary, encode_multipart_formdata  # type: ignore[assignment]
     from urllib3_future.util import parse_url  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions._async import AsyncExtensionFromHTTP  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions import ExtensionFromHTTP  # type: ignore[assignment]
+    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
+        AsyncWebSocketExtensionFromHTTP,
+        AsyncRawExtensionFromHTTP,
+    )
+    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
+        WebSocketExtensionFromHTTP,
+        RawExtensionFromHTTP,
+    )
 
 from ._typing import (
     BodyFormType,
@@ -1023,10 +1035,21 @@ class Response:
         self.download_progress: TransferProgress | None = None
 
     @property
-    def extension(self) -> ExtensionFromHTTP | None:
-        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler."""
+    def extension(
+        self,
+    ) -> (
+        WebSocketExtensionFromHTTP
+        | RawExtensionFromHTTP
+        | AsyncWebSocketExtensionFromHTTP
+        | AsyncRawExtensionFromHTTP
+        | None
+    ):
+        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler.
+        If the server opened a WebSocket, then the extension will be of type WebSocketExtensionFromHTTP.
+        Otherwise, on unknown protocol, it will be RawExtensionFromHTTP.
+        Warning: If you stand in an async inclosure, the type will be AsyncWebSocketExtensionFromHTTP or AsyncRawExtensionFromHTTP."""
         return (
-            self.raw.extension
+            self.raw.extension  # type: ignore[return-value]
             if self.raw is not None and hasattr(self.raw, "extension")
             else None
         )
@@ -1612,10 +1635,14 @@ class AsyncResponse(Response):
     }
 
     @property
-    def extension(self) -> AsyncExtensionFromHTTP | None:  # type: ignore[override]
-        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler."""
+    def extension(  # type: ignore[override]
+        self,
+    ) -> AsyncWebSocketExtensionFromHTTP | AsyncRawExtensionFromHTTP | None:
+        """Access the I/O after an Upgraded connection. E.g. for a WebSocket handler.
+        If the server opened a WebSocket, then the extension will be of type AsyncWebSocketExtensionFromHTTP.
+        Otherwise, on unknown protocol, it will be AsyncRawExtensionFromHTTP."""
         return (
-            self.raw.extension
+            self.raw.extension  # type: ignore[return-value]
             if self.raw is not None and hasattr(self.raw, "extension")
             else None
         )

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1223,6 +1223,7 @@ class Session:
                 del kwargs["multiplexed"]
                 del kwargs["on_upload_body"]
                 del kwargs["on_post_connection"]
+                del kwargs["on_early_response"]
 
                 r = adapter.send(request, **kwargs)
 

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1186,6 +1186,7 @@ class Session:
                     max_retries=self.retries,
                     disable_http1=self._disable_http1,
                     disable_http2=self._disable_http2,
+                    disable_http3=self._disable_http3,
                     resolver=self.resolver,
                     source_address=self.source_address,
                     disable_ipv4=self._disable_ipv4,

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -67,7 +67,7 @@ else:
     )
     from urllib3_future import ConnectionInfo  # type: ignore[assignment]
     from urllib3_future.contrib.webextensions import load_extension, ExtensionFromHTTP  # type: ignore[assignment]
-    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP  # type: ignore[assignment]
+    from urllib3_future.contrib.webextensions._async import AsyncExtensionFromHTTP  # type: ignore[assignment]
 
 from .__version__ import __version__
 from .exceptions import InvalidURL, UnrewindableBodyError, MissingSchema

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -50,7 +50,8 @@ if HAS_LEGACY_URLLIB3 is False:
         AsyncManyResolver,
     )
     from urllib3 import ConnectionInfo
-    from urllib3.contrib.webextensions import load_extension
+    from urllib3.contrib.webextensions import load_extension, ExtensionFromHTTP
+    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP
 else:
     from urllib3_future.util import make_headers, parse_url  # type: ignore[assignment]
     from urllib3_future.contrib.resolver import (  # type: ignore[assignment]
@@ -65,7 +66,8 @@ else:
         AsyncManyResolver,
     )
     from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions import load_extension  # type: ignore[assignment]
+    from urllib3_future.contrib.webextensions import load_extension, ExtensionFromHTTP  # type: ignore[assignment]
+    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP  # type: ignore[assignment]
 
 from .__version__ import __version__
 from .exceptions import InvalidURL, UnrewindableBodyError, MissingSchema
@@ -1237,3 +1239,193 @@ def is_ocsp_capable(conn_info: ConnectionInfo | None) -> bool:
         return False
 
     return True
+
+
+def wrap_extension_for_http(
+    extension: type[ExtensionFromHTTP],
+) -> type[ExtensionFromHTTP]:
+    """
+    We want to properly map exceptions from bellow (urllib3-future) into our own exceptions.
+    This function purposely wrap the extension class to achieve that.
+    Warning: synchronous context only!
+    """
+    if HAS_LEGACY_URLLIB3 is False:
+        from urllib3.exceptions import (
+            ClosedPoolError,
+            HTTPError as _HTTPError,
+            InvalidHeader as _InvalidHeader,
+            ProtocolError,
+            ProxyError as _ProxyError,
+            ReadTimeoutError,
+            SSLError as _SSLError,
+            DecodeError,
+        )
+    else:
+        from urllib3_future.exceptions import (  # type: ignore[assignment]
+            ClosedPoolError,
+            HTTPError as _HTTPError,
+            InvalidHeader as _InvalidHeader,
+            ProtocolError,
+            ProxyError as _ProxyError,
+            ReadTimeoutError,
+            SSLError as _SSLError,
+            DecodeError,
+        )
+
+    from .exceptions import (
+        ConnectionError,
+        InvalidHeader,
+        ProxyError,
+        ReadTimeout,
+        SSLError as RequestsSSLError,
+        ContentDecodingError,
+        ChunkedEncodingError,
+    )
+
+    class _WrappedExtensionFromHTTP(extension):  # type: ignore[valid-type,misc]
+        def next_payload(self) -> str | bytes | None:
+            try:
+                return super().next_payload()
+            except ProtocolError as e:
+                raise ChunkedEncodingError(e)
+            except DecodeError as e:
+                raise ContentDecodingError(e)
+            except ReadTimeoutError as e:
+                raise ReadTimeout(e)
+            except _SSLError as e:
+                raise RequestsSSLError(e)
+
+        def send_payload(self, buf: str | bytes) -> None:
+            try:
+                super().send_payload(buf)
+            except (ProtocolError, OSError) as err:
+                raise ConnectionError(err)
+            except ClosedPoolError as e:
+                raise ConnectionError(e)
+            except _ProxyError as e:
+                raise ProxyError(e)
+            except (_SSLError, _HTTPError) as e:
+                if isinstance(e, _SSLError):
+                    raise RequestsSSLError(e)
+                elif isinstance(e, ReadTimeoutError):
+                    raise ReadTimeout(e)
+                elif isinstance(e, _InvalidHeader):
+                    raise InvalidHeader(e)
+                else:
+                    raise
+
+        def close(self) -> None:
+            try:
+                super().close()
+            except (ProtocolError, OSError) as err:
+                raise ConnectionError(err)
+            except ClosedPoolError as e:
+                raise ConnectionError(e)
+            except _ProxyError as e:
+                raise ProxyError(e)
+            except (_SSLError, _HTTPError) as e:
+                if isinstance(e, _SSLError):
+                    raise RequestsSSLError(e)
+                elif isinstance(e, ReadTimeoutError):
+                    raise ReadTimeout(e)
+                elif isinstance(e, _InvalidHeader):
+                    raise InvalidHeader(e)
+                else:
+                    raise
+
+    return _WrappedExtensionFromHTTP
+
+
+def async_wrap_extension_for_http(
+    extension: type[AsyncExtensionFromHTTP],
+) -> type[AsyncExtensionFromHTTP]:
+    """
+    We want to properly map exceptions from bellow (urllib3-future) into our own exceptions.
+    This function purposely wrap the extension class to achieve that.
+    Warning: asynchronous context only!
+    """
+    if HAS_LEGACY_URLLIB3 is False:
+        from urllib3.exceptions import (
+            ClosedPoolError,
+            HTTPError as _HTTPError,
+            InvalidHeader as _InvalidHeader,
+            ProtocolError,
+            ProxyError as _ProxyError,
+            ReadTimeoutError,
+            SSLError as _SSLError,
+            DecodeError,
+        )
+    else:
+        from urllib3_future.exceptions import (  # type: ignore[assignment]
+            ClosedPoolError,
+            HTTPError as _HTTPError,
+            InvalidHeader as _InvalidHeader,
+            ProtocolError,
+            ProxyError as _ProxyError,
+            ReadTimeoutError,
+            SSLError as _SSLError,
+            DecodeError,
+        )
+
+    from .exceptions import (
+        ConnectionError,
+        InvalidHeader,
+        ProxyError,
+        ReadTimeout,
+        SSLError as RequestsSSLError,
+        ContentDecodingError,
+        ChunkedEncodingError,
+    )
+
+    class _AsyncWrappedExtensionFromHTTP(extension):  # type: ignore[valid-type,misc]
+        async def next_payload(self) -> str | bytes | None:
+            try:
+                return await super().next_payload()
+            except ProtocolError as e:
+                raise ChunkedEncodingError(e)
+            except DecodeError as e:
+                raise ContentDecodingError(e)
+            except ReadTimeoutError as e:
+                raise ReadTimeout(e)
+            except _SSLError as e:
+                raise RequestsSSLError(e)
+
+        async def send_payload(self, buf: str | bytes) -> None:
+            try:
+                await super().send_payload(buf)
+            except (ProtocolError, OSError) as err:
+                raise ConnectionError(err)
+            except ClosedPoolError as e:
+                raise ConnectionError(e)
+            except _ProxyError as e:
+                raise ProxyError(e)
+            except (_SSLError, _HTTPError) as e:
+                if isinstance(e, _SSLError):
+                    raise RequestsSSLError(e)
+                elif isinstance(e, ReadTimeoutError):
+                    raise ReadTimeout(e)
+                elif isinstance(e, _InvalidHeader):
+                    raise InvalidHeader(e)
+                else:
+                    raise
+
+        async def close(self) -> None:
+            try:
+                await super().close()
+            except (ProtocolError, OSError) as err:
+                raise ConnectionError(err)
+            except ClosedPoolError as e:
+                raise ConnectionError(e)
+            except _ProxyError as e:
+                raise ProxyError(e)
+            except (_SSLError, _HTTPError) as e:
+                if isinstance(e, _SSLError):
+                    raise RequestsSSLError(e)
+                elif isinstance(e, ReadTimeoutError):
+                    raise ReadTimeout(e)
+                elif isinstance(e, _InvalidHeader):
+                    raise InvalidHeader(e)
+                else:
+                    raise
+
+    return _AsyncWrappedExtensionFromHTTP


### PR DESCRIPTION
3.9.1 (2024-10-13)
------------------

**Fixed**
- Exception leak from urllib3-future when using WebSocket.
- Enforcing HTTP/3 in an AsyncSession. (#152)
- Adapter kwargs fallback to support old Requests extensions.
- Type hint for ``Response.extension`` linked to the generic interface instead of the inherited ones.
- Accessing WS over HTTP/2+ using the synchronous session object.

**Misc**
- Documentation improvement for in-memory certificates and WebSocket use cases.  (#151)

**Changed**
- urllib3-future lower bound version is raised to 2.10.904 to ensure exception are properly translated into urllib3-future ones for WS.
