### PR TITLE
Fix in session defaults for verify, and stream

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,13 @@ jobs:
             os: ubuntu-22.04
           - python-version: pypy-3.8
             os: macOS-13
+        exclude:
+          # pypy 3.9 and 3.10 suffers from a wierd bug, probably due to gc
+          # this bug prevent us from running the suite on Windows.
+          - python-version: pypy-3.9
+            os: windows-latest
+          - python-version: pypy-3.10
+            os: windows-latest
 
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.10.2 (2024-10-25)
+------------------
+
+**Fixed**
+- Ensure `stream`, and `verify` both defaults to your ``Session`` parameters.
+
 3.10.1 (2024-10-22)
 ------------------
 

--- a/docs/dev/migrate.rst
+++ b/docs/dev/migrate.rst
@@ -45,7 +45,7 @@ The library itself (sources) should be really easy to migrate (cf. developer mig
 but the tests may be harder to adapt.
 
 The main reason behind this difficulty is often related to a strong tie with third-party
-mocking library such as ``response``.
+mocking library such as ``responses``.
 
 To overcome this, we will introduce you to a clever bypass. If you are using pytest, do the
 following in your ``conftest.py``, see https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
@@ -65,3 +65,9 @@ for more information. (The goal would simply to execute the following piece of c
     modules["requests.packages.urllib3"] = urllib3
 
 .. warning:: This code sample is only to be executed in a development environment, it permit to fool the third-party dependencies that have a strong tie on Requests.
+
+.. warning:: Some pytest plugins may load/import Requests at startup.
+    Disable the plugin auto-loading first by either passing ``PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`` (in environment)
+    or ``pytest -p "no:pytest-betamax"`` in CLI parameters. Replace ``pytest-betamax`` by the name of the target plugin.
+    To find out the name of the plugin auto-loaded, execute ``pytest --trace-config`` as the name aren't usually what
+    you would expect them to be.

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -379,6 +379,29 @@ Note that connections are only released back to the pool for reuse once all body
 data has been read; be sure to either set ``stream`` to ``False`` or read the
 ``content`` property of the ``Response`` object.
 
+.. note:: Available since Niquests v3.10 and before this only HTTP/1.1 were kept alive properly.
+
+Niquests can automatically make sure that your HTTP connection is kept alive
+no matter the used protocol using a discrete scheduled task for each host.
+
+.. code-block:: python
+
+    import niquests
+
+    sess = niquests.Session(keepalive_delay=300, keepalive_idle_window=60)  # already the defaults!, you don't need to specify anything
+
+In that example, we indicate that we wish to keep a connection alive for 5 minutes and
+eventually send ping every 60s after the connection was idle. (Those values are the default ones!)
+
+The pings are only sent when using HTTP/2 or HTTP/3 over QUIC. Any connection activity is considered as used, therefor
+making the ping only 60s after zero activity. If the connection receive unsolicited data, it is also considered used.
+
+.. note:: Setting either keepalive_delay or keepalive_idle_window to None disable this feature.
+
+.. warning:: We do not recommend setting anything lower than 30s for keepalive_idle_window. Anything lower than 1s is considered to be 1s. High frequency ping will lower the performance of your connection pool. And probably end up by getting kicked out by the server.
+
+Once the ``keepalive_delay`` passed, we do not close the connection, we simply cease to ensure it is alive. This is purely for backward compatibility with our predecessor, as some host may retain the connection for hours.
+
 .. _streaming-uploads:
 
 Streaming Uploads

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -1249,32 +1249,6 @@ See::
 
 .. note:: The given example are really basic ones. You may adjust at will the settings and algorithm to match your requisites.
 
-Keep-Alive
-----------
-
-.. note:: Available since Niquests v3.10 and before this only HTTP/1.1 were kept alive properly.
-
-Niquests can automatically make sure that your HTTP connection is kept alive
-no matter the used protocol using a discrete scheduled task for each host.
-
-.. code-block:: python
-
-    import niquests
-
-    sess = niquests.Session(keepalive_delay=300, keepalive_idle_window=60)  # already the defaults!, you don't need to specify anything
-
-In that example, we indicate that we wish to keep a connection alive for 5 minutes and
-eventually send ping every 60s after the connection was idle. (Those values are the default ones!)
-
-The pings are only sent when using HTTP/2 or HTTP/3 over QUIC. Any connection activity is considered as used, therefor
-making the ping only 60s after zero activity. If the connection receive unsolicited data, it is also considered used.
-
-.. note:: Setting either keepalive_delay or keepalive_idle_window to None disable this feature.
-
-.. warning:: We do not recommend setting anything lower than 30s for keepalive_idle_window. Anything lower than 1s is considered to be 1s. High frequency ping will lower the performance of your connection pool. And probably end up by getting kicked out by the server.
-
-Once the ``keepalive_delay`` passed, we do not close the connection, we simply cease to ensure it is alive. This is purely for backward compatibility with our predecessor, as some host may retain the connection for hours.
-
 -----------------------
 
 Ready for more? Check out the :ref:`advanced <advanced>` section.

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.10.1"
+__version__ = "3.10.2"
 
-__build__: int = 0x031001
+__build__: int = 0x031002
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -862,7 +862,7 @@ class AsyncSession(Session):
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
         verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
     ) -> Response: ...
@@ -898,8 +898,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
         **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
@@ -933,8 +933,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
     ) -> Response: ...
@@ -952,7 +952,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
@@ -970,8 +970,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
         **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
@@ -1005,8 +1005,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
     ) -> Response: ...
@@ -1024,7 +1024,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
@@ -1042,8 +1042,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
         **kwargs: typing.Any,
     ) -> Response | AsyncResponse:
@@ -1080,8 +1080,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
     ) -> Response: ...
 
@@ -1101,7 +1101,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
     ) -> AsyncResponse: ...
@@ -1121,8 +1121,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
@@ -1160,8 +1160,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
     ) -> Response: ...
 
@@ -1181,7 +1181,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
     ) -> AsyncResponse: ...
@@ -1201,8 +1201,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
@@ -1240,8 +1240,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
     ) -> Response: ...
 
@@ -1261,7 +1261,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
     ) -> AsyncResponse: ...
@@ -1281,8 +1281,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
     ) -> Response | AsyncResponse:
         return await self.request(  # type: ignore[call-overload,misc]
@@ -1317,8 +1317,8 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
-        stream: Literal[False] = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
     ) -> Response: ...
@@ -1336,7 +1336,7 @@ class AsyncSession(Session):
         allow_redirects: bool = ...,
         proxies: ProxyType | None = ...,
         hooks: HookType[PreparedRequest | Response] | None = ...,
-        verify: TLSVerifyType = ...,
+        verify: TLSVerifyType | None = ...,
         stream: Literal[True],
         cert: TLSClientCertType | None = ...,
         **kwargs: typing.Any,
@@ -1354,8 +1354,8 @@ class AsyncSession(Session):
         allow_redirects: bool = True,
         proxies: ProxyType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
-        verify: TLSVerifyType = True,
-        stream: bool = False,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
         cert: TLSClientCertType | None = None,
         **kwargs: typing.Any,
     ) -> Response | AsyncResponse:


### PR DESCRIPTION
3.10.2 (2024-10-25)
------------------

**Fixed**
- Ensure `stream`, and `verify` both defaults to your ``Session`` parameters. (#165)
