### PR TITLE
chore(models): use preferred notation for JSON content-type

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -528,7 +528,7 @@ class PreparedRequest:
         if not data and json is not None:
             # urllib3 requires a bytes-like body. Python 2's json.dumps
             # provides this natively, but Python 3 gives a Unicode string.
-            content_type = 'application/json; charset="utf-8"'
+            content_type = "application/json;charset=utf-8"
             json_kwargs = {}
 
             if not hasattr(_json, "orjson"):


### PR DESCRIPTION
I noticed that the content-type looked like this:
`"Content-Type": "application/json; charset=\"utf-8\"",`

and then I checked the corresponding RFC (7231) to see if that's valid.
It is valid, but not the preferred way.

![image](https://github.com/user-attachments/assets/c55b1fc8-4140-4cf2-8595-7a6098c3fda1)


---

Update: [reference to RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-media-type)