### PR TITLE
Release 3.12.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,28 +2,23 @@ exclude: 'docs/|ext/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: check-yaml
   - id: debug-statements
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.1
-  hooks:
-    - id: pyupgrade
-      args: [--py37-plus]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.3.2
+  rev: v0.9.1
   hooks:
     # Run the linter.
     - id: ruff
-      args: [ --fix ]
+      args: [ --fix, --target-version=py37 ]
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.12.1
+  rev: v1.14.1
   hooks:
   -   id: mypy
       args: [--check-untyped-defs]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,20 @@
 Release History
 ===============
 
+3.12.2 (2025-01-22)
+-------------------
+
+**Fixed**
+- Parsing of special scheme that exceed 9 characters on rare custom adapters.
+
+**Changed**
+- Default `Content-Type` for json payloads changed from `application/json; charset="utf-8"` to `application/json;charset=utf-8`.
+  While the previous default was valid, this is the preferred value according to RFC9110. (#204)
+
+**Misc**
+- Removed a useless hasattr control to support older version of urllib3-future (<2.5).
+- Updated our pre-commit configuration and reformatted files accordingly.
+
 3.12.1 (2025-01-03)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,20 @@ packages = [
     "src/niquests",
 ]
 
-[tool.isort]
-profile = "black"
-src_paths = ["src/niquests", "tests"]
-honor_noqa = true
-add_imports = "from __future__ import annotations"
+[tool.ruff]
+line-length = 128
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "W",  # pycodestyle
+    "I",  # isort
+    "U",  # pyupgrade
+]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"

--- a/src/niquests/__init__.py
+++ b/src/niquests/__init__.py
@@ -48,14 +48,17 @@ from logging import NullHandler
 from ._compat import HAS_LEGACY_URLLIB3
 
 if HAS_LEGACY_URLLIB3 is False:
+    from urllib3 import Retry as RetryConfiguration
+    from urllib3 import Timeout as TimeoutConfiguration
     from urllib3.exceptions import DependencyWarning
-    from urllib3 import Timeout as TimeoutConfiguration, Retry as RetryConfiguration
 else:
-    from urllib3_future.exceptions import DependencyWarning  # type: ignore[assignment]
     from urllib3_future import (  # type: ignore[assignment]
-        Timeout as TimeoutConfiguration,
         Retry as RetryConfiguration,
     )
+    from urllib3_future import (  # type: ignore[assignment]
+        Timeout as TimeoutConfiguration,
+    )
+    from urllib3_future.exceptions import DependencyWarning  # type: ignore[assignment]
 
 # urllib3's DependencyWarnings should be silenced.
 warnings.simplefilter("ignore", DependencyWarning)
@@ -89,7 +92,7 @@ from .exceptions import (
     TooManyRedirects,
     URLRequired,
 )
-from .models import PreparedRequest, Request, Response, AsyncResponse
+from .models import AsyncResponse, PreparedRequest, Request, Response
 from .sessions import Session
 from .status_codes import codes
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.12.1"
+__version__ = "3.12.2"
 
-__build__: int = 0x031201
+__build__: int = 0x031202
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_compat.py
+++ b/src/niquests/_compat.py
@@ -28,9 +28,7 @@ except (ImportError, AttributeError):  # Defensive: tested in separate CI
     urllib3 = None  # type: ignore[assignment]
 
 
-if (urllib3 is None and urllib3_future is None) or (
-    HAS_LEGACY_URLLIB3 and urllib3_future is None
-):
+if (urllib3 is None and urllib3_future is None) or (HAS_LEGACY_URLLIB3 and urllib3_future is None):
     raise RuntimeError(  # Defensive: tested in separate CI
         "This is awkward but your environment is missing urllib3-future. "
         "Your environment seems broken. "

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -1,30 +1,32 @@
 from __future__ import annotations
 
-from os import PathLike
 import typing
 from http.cookiejar import CookieJar
+from os import PathLike
 
 from kiss_headers import Headers
 
 from ._compat import HAS_LEGACY_URLLIB3
 
 if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ResolverDescription, Retry, Timeout, AsyncResolverDescription
+    from urllib3 import AsyncResolverDescription, ResolverDescription, Retry, Timeout
     from urllib3.contrib.resolver import BaseResolver
     from urllib3.contrib.resolver._async import AsyncBaseResolver
     from urllib3.fields import RequestField
 else:  # Defensive: tested in separate/isolated CI
     from urllib3_future import (  # type: ignore[assignment]
+        AsyncResolverDescription,
+        ResolverDescription,
         Retry,
         Timeout,
-        ResolverDescription,
-        AsyncResolverDescription,
+    )
+    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
+    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
+        AsyncBaseResolver,
     )
     from urllib3_future.fields import RequestField  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import AsyncBaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
 
-from .auth import AuthBase, AsyncAuthBase
+from .auth import AsyncAuthBase, AuthBase
 from .structures import CaseInsensitiveDict
 
 if typing.TYPE_CHECKING:
@@ -74,16 +76,12 @@ CookiesType: typing.TypeAlias = typing.Union[
 #: Either Yes/No, or CA bundle pem location. Or directly the raw bundle content itself.
 TLSVerifyType: typing.TypeAlias = typing.Union[bool, str, bytes, PathLike]
 #: Accept a pem certificate (concat cert, key) or an explicit tuple of cert, key pair with an optional password.
-TLSClientCertType: typing.TypeAlias = typing.Union[
-    str, typing.Tuple[str, str], typing.Tuple[str, str, str]
-]
+TLSClientCertType: typing.TypeAlias = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
 #: All accepted ways to describe desired timeout.
 TimeoutType: typing.TypeAlias = typing.Union[
     int,  # TotalTimeout
     float,  # TotalTimeout
-    typing.Tuple[
-        typing.Union[int, float], typing.Union[int, float]
-    ],  # note: TotalTimeout, ConnectTimeout
+    typing.Tuple[typing.Union[int, float], typing.Union[int, float]],  # note: TotalTimeout, ConnectTimeout
     typing.Tuple[
         typing.Union[int, float], typing.Union[int, float], typing.Union[int, float]
     ],  # note: TotalTimeout, ConnectTimeout, ReadTimeout
@@ -144,9 +142,7 @@ FieldTupleType: typing.TypeAlias = typing.Union[
     typing.Tuple[str, FieldValueType, str],
 ]
 
-FieldSequenceType: typing.TypeAlias = typing.Sequence[
-    typing.Union[typing.Tuple[str, FieldTupleType], RequestField]
-]
+FieldSequenceType: typing.TypeAlias = typing.Sequence[typing.Union[typing.Tuple[str, FieldTupleType], RequestField]]
 FieldsType: typing.TypeAlias = typing.Union[
     FieldSequenceType,
     typing.Mapping[str, FieldTupleType],
@@ -166,13 +162,9 @@ AsyncHookCallableType: typing.TypeAlias = typing.Callable[
     typing.Awaitable[typing.Optional[_HV]],
 ]
 
-AsyncHookType: typing.TypeAlias = typing.Dict[
-    str, typing.List[typing.Union[HookCallableType[_HV], AsyncHookCallableType[_HV]]]
-]
+AsyncHookType: typing.TypeAlias = typing.Dict[str, typing.List[typing.Union[HookCallableType[_HV], AsyncHookCallableType[_HV]]]]
 
-CacheLayerAltSvcType: typing.TypeAlias = typing.MutableMapping[
-    typing.Tuple[str, int], typing.Optional[typing.Tuple[str, int]]
-]
+CacheLayerAltSvcType: typing.TypeAlias = typing.MutableMapping[typing.Tuple[str, int], typing.Optional[typing.Tuple[str, int]]]
 
 RetryType: typing.TypeAlias = typing.Union[bool, int, Retry]
 

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -30,42 +30,25 @@ from ._compat import HAS_LEGACY_URLLIB3, urllib3_ensure_type
 
 if HAS_LEGACY_URLLIB3 is False:
     from urllib3 import (
+        AsyncHTTPConnectionPool,
+        AsyncHTTPSConnectionPool,
+        AsyncPoolManager,
+        AsyncProxyManager,
+        AsyncResolverDescription,
+        BaseHTTPResponse,
         ConnectionInfo,
         HTTPConnectionPool,
-        AsyncHTTPConnectionPool,
         HTTPSConnectionPool,
-        AsyncHTTPSConnectionPool,
-        ResolverDescription,
-        AsyncResolverDescription,
-        PoolManager,
-        AsyncPoolManager,
-        ProxyManager,
-        AsyncProxyManager,
-        proxy_from_url,
-        async_proxy_from_url,
         HttpVersion,
+        PoolManager,
+        ProxyManager,
+        ResolverDescription,
         ResponsePromise,
-        BaseHTTPResponse,
+        async_proxy_from_url,
+        proxy_from_url,
+    )
+    from urllib3 import (
         AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3.exceptions import (
-        ClosedPoolError,
-        ConnectTimeoutError,
-        HTTPError as _HTTPError,
-        InvalidHeader as _InvalidHeader,
-        LocationValueError,
-        MaxRetryError,
-        NewConnectionError,
-        ProtocolError,
-        ProxyError as _ProxyError,
-        ReadTimeoutError,
-        ResponseError,
-        SSLError as _SSLError,
-    )
-    from urllib3.util import (
-        Timeout as TimeoutSauce,
-        parse_url,
-        Retry,
     )
     from urllib3.contrib.resolver import BaseResolver
     from urllib3.contrib.resolver._async import AsyncBaseResolver
@@ -73,54 +56,100 @@ if HAS_LEGACY_URLLIB3 is False:
     from urllib3.contrib.webextensions._async import (
         load_extension as async_load_extension,
     )
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import (  # type: ignore[assignment]
-        ConnectionInfo,
-        HTTPConnectionPool,
-        AsyncHTTPConnectionPool,
-        HTTPSConnectionPool,
-        AsyncHTTPSConnectionPool,
-        ResolverDescription,
-        AsyncResolverDescription,
-        PoolManager,
-        AsyncPoolManager,
-        ProxyManager,
-        AsyncProxyManager,
-        proxy_from_url,
-        async_proxy_from_url,
-        HttpVersion,
-        ResponsePromise,
-        BaseHTTPResponse,
-        AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
+    from urllib3.exceptions import (
         ClosedPoolError,
         ConnectTimeoutError,
-        HTTPError as _HTTPError,
-        InvalidHeader as _InvalidHeader,
         LocationValueError,
         MaxRetryError,
         NewConnectionError,
         ProtocolError,
-        ProxyError as _ProxyError,
         ReadTimeoutError,
         ResponseError,
+    )
+    from urllib3.exceptions import (
+        HTTPError as _HTTPError,
+    )
+    from urllib3.exceptions import (
+        InvalidHeader as _InvalidHeader,
+    )
+    from urllib3.exceptions import (
+        ProxyError as _ProxyError,
+    )
+    from urllib3.exceptions import (
+        SSLError as _SSLError,
+    )
+    from urllib3.util import (
+        Retry,
+        parse_url,
+    )
+    from urllib3.util import (
+        Timeout as TimeoutSauce,
+    )
+else:  # Defensive: tested in separate/isolated CI
+    from urllib3_future import (  # type: ignore[assignment]
+        AsyncHTTPConnectionPool,
+        AsyncHTTPSConnectionPool,
+        AsyncPoolManager,
+        AsyncProxyManager,
+        AsyncResolverDescription,
+        BaseHTTPResponse,
+        ConnectionInfo,
+        HTTPConnectionPool,
+        HTTPSConnectionPool,
+        HttpVersion,
+        PoolManager,
+        ProxyManager,
+        ResolverDescription,
+        ResponsePromise,
+        async_proxy_from_url,
+        proxy_from_url,
+    )
+    from urllib3_future import (  # type: ignore[assignment]
+        AsyncHTTPResponse as BaseAsyncHTTPResponse,
+    )
+    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
+    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
+        AsyncBaseResolver,
+    )
+    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
+        load_extension,
+    )
+    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
+        load_extension as async_load_extension,
+    )
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
+        ClosedPoolError,
+        ConnectTimeoutError,
+        LocationValueError,
+        MaxRetryError,
+        NewConnectionError,
+        ProtocolError,
+        ReadTimeoutError,
+        ResponseError,
+    )
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
+        HTTPError as _HTTPError,
+    )
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
+        InvalidHeader as _InvalidHeader,
+    )
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
+        ProxyError as _ProxyError,
+    )
+    from urllib3_future.exceptions import (  # type: ignore[assignment]
         SSLError as _SSLError,
     )
     from urllib3_future.util import (  # type: ignore[assignment]
-        Timeout as TimeoutSauce,
-        parse_url,
         Retry,
+        parse_url,
     )
-    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import AsyncBaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions import load_extension  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
-        load_extension as async_load_extension,
+    from urllib3_future.util import (  # type: ignore[assignment]
+        Timeout as TimeoutSauce,
     )
 
 from ._constant import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES
 from ._typing import (
+    AsyncResolverType,
     CacheLayerAltSvcType,
     HookType,
     ProxyType,
@@ -128,7 +157,6 @@ from ._typing import (
     RetryType,
     TLSClientCertType,
     TLSVerifyType,
-    AsyncResolverType,
 )
 from .auth import _basic_auth_str
 from .cookies import extract_cookies_to_jar
@@ -139,39 +167,39 @@ from .exceptions import (
     InvalidProxyURL,
     InvalidSchema,
     InvalidURL,
+    MissingSchema,
     MultiplexingError,
     ProxyError,
     ReadTimeout,
     RetryError,
     SSLError,
     TooManyRedirects,
-    MissingSchema,
 )
-from .hooks import dispatch_hook, async_dispatch_hook
-from .models import PreparedRequest, Response, AsyncResponse
+from .hooks import async_dispatch_hook, dispatch_hook
+from .models import AsyncResponse, PreparedRequest, Response
 from .structures import CaseInsensitiveDict
 from .utils import (
+    _deepcopy_ci,
+    _swap_context,
+    async_wrap_extension_for_http,
     get_auth_from_url,
     get_encoding_from_headers,
+    is_ocsp_capable,
+    parse_scheme,
     prepend_scheme_if_needed,
+    resolve_socket_family,
     select_proxy,
     urldefragauth,
-    resolve_socket_family,
-    _swap_context,
-    _deepcopy_ci,
-    parse_scheme,
-    is_ocsp_capable,
     wrap_extension_for_http,
-    async_wrap_extension_for_http,
 )
 
 try:
     if HAS_LEGACY_URLLIB3 is False:
-        from urllib3.contrib.socks import SOCKSProxyManager, AsyncSOCKSProxyManager
+        from urllib3.contrib.socks import AsyncSOCKSProxyManager, SOCKSProxyManager
     else:
         from urllib3_future.contrib.socks import (  # type: ignore[assignment]
-            SOCKSProxyManager,
             AsyncSOCKSProxyManager,
+            SOCKSProxyManager,
         )
 except ImportError:
 
@@ -197,8 +225,7 @@ class BaseAdapter:
         cert: TLSClientCertType | None = None,
         proxies: ProxyType | None = None,
         on_post_connection: typing.Callable[[typing.Any], None] | None = None,
-        on_upload_body: typing.Callable[[int, int | None, bool, bool], None]
-        | None = None,
+        on_upload_body: typing.Callable[[int, int | None, bool, bool], None] | None = None,
         on_early_response: typing.Callable[[Response], None] | None = None,
         multiplexed: bool = False,
     ) -> Response:
@@ -250,14 +277,9 @@ class AsyncBaseAdapter:
         verify: TLSVerifyType = True,
         cert: TLSClientCertType | None = None,
         proxies: ProxyType | None = None,
-        on_post_connection: typing.Callable[[typing.Any], typing.Awaitable[None]]
-        | None = None,
-        on_upload_body: typing.Callable[
-            [int, int | None, bool, bool], typing.Awaitable[None]
-        ]
-        | None = None,
-        on_early_response: typing.Callable[[Response], typing.Awaitable[None]]
-        | None = None,
+        on_post_connection: typing.Callable[[typing.Any], typing.Awaitable[None]] | None = None,
+        on_upload_body: typing.Callable[[int, int | None, bool, bool], typing.Awaitable[None]] | None = None,
+        on_early_response: typing.Callable[[Response], typing.Awaitable[None]] | None = None,
         multiplexed: bool = False,
     ) -> AsyncResponse:
         """Sends PreparedRequest object. Returns Response object.
@@ -365,9 +387,7 @@ class HTTPAdapter(BaseAdapter):
             self.max_retries = urllib3_ensure_type(max_retries)  # type: ignore[type-var]
         else:
             if max_retries < 0:
-                raise ValueError(
-                    "configured retries count is invalid. you must specify a positive or zero integer value."
-                )
+                raise ValueError("configured retries count is invalid. you must specify a positive or zero integer value.")
             self.max_retries = Retry.from_int(max_retries)
             # Kept for backward compatibility.
             if max_retries == 0:
@@ -598,10 +618,7 @@ class HTTPAdapter(BaseAdapter):
                             cert_loc = cert_loc.decode()
 
                     if isinstance(cert_loc, str) and not os.path.exists(cert_loc):
-                        raise OSError(
-                            f"Could not find a suitable TLS CA certificate bundle, "
-                            f"invalid path: {cert_loc}"
-                        )
+                        raise OSError(f"Could not find a suitable TLS CA certificate bundle, invalid path: {cert_loc}")
 
                 if not assert_fingerprint:
                     if conn.cert_reqs != "CERT_REQUIRED":
@@ -666,14 +683,9 @@ class HTTPAdapter(BaseAdapter):
                 conn.key_file = None
                 conn.key_password = None
             if conn.cert_file and not os.path.exists(conn.cert_file):
-                raise OSError(
-                    f"Could not find the TLS certificate file, "
-                    f"invalid path: {conn.cert_file}"
-                )
+                raise OSError(f"Could not find the TLS certificate file, invalid path: {conn.cert_file}")
             if conn.key_file and not os.path.exists(conn.key_file):
-                raise OSError(
-                    f"Could not find the TLS key file, invalid path: {conn.key_file}"
-                )
+                raise OSError(f"Could not find the TLS key file, invalid path: {conn.key_file}")
 
         if need_reboot_conn:
             if conn.is_idle:
@@ -685,9 +697,7 @@ class HTTPAdapter(BaseAdapter):
                     UserWarning,
                 )
 
-    def build_response(
-        self, req: PreparedRequest, resp: BaseHTTPResponse | ResponsePromise
-    ) -> Response:
+    def build_response(self, req: PreparedRequest, resp: BaseHTTPResponse | ResponsePromise) -> Response:
         """Builds a :class:`Response <requests.Response>` object from a urllib3
         response. This should not be called from user code, and is only exposed
         for use when subclassing the
@@ -730,9 +740,7 @@ class HTTPAdapter(BaseAdapter):
 
         return response
 
-    def get_connection(
-        self, url: str, proxies: ProxyType | None = None
-    ) -> HTTPConnectionPool | HTTPSConnectionPool:
+    def get_connection(self, url: str, proxies: ProxyType | None = None) -> HTTPConnectionPool | HTTPSConnectionPool:
         """Returns a urllib3 connection for the given URL. This should not be
         called from user code, and is only exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
@@ -746,10 +754,7 @@ class HTTPAdapter(BaseAdapter):
             proxy = prepend_scheme_if_needed(proxy, "http")
             proxy_url = parse_url(proxy)
             if not proxy_url.host:
-                raise InvalidProxyURL(
-                    "Please check proxy URL. It is malformed "
-                    "and could be missing the host."
-                )
+                raise InvalidProxyURL("Please check proxy URL. It is malformed and could be missing the host.")
             proxy_manager = self.proxy_manager_for(proxy)
             conn = proxy_manager.connection_from_url(url)
         else:
@@ -843,8 +848,7 @@ class HTTPAdapter(BaseAdapter):
         cert: TLSClientCertType | None = None,
         proxies: ProxyType | None = None,
         on_post_connection: typing.Callable[[typing.Any], None] | None = None,
-        on_upload_body: typing.Callable[[int, int | None, bool, bool], None]
-        | None = None,
+        on_upload_body: typing.Callable[[int, int | None, bool, bool], None] | None = None,
         on_early_response: typing.Callable[[Response], None] | None = None,
         multiplexed: bool = False,
     ) -> Response:
@@ -868,11 +872,9 @@ class HTTPAdapter(BaseAdapter):
             if available. Return a lazy instance of Response pending its retrieval.
         """
 
-        assert (
-            request.url is not None
-            and request.headers is not None
-            and request.method is not None
-        ), "Tried to send a non-initialized PreparedRequest"
+        assert request.url is not None and request.headers is not None and request.method is not None, (
+            "Tried to send a non-initialized PreparedRequest"
+        )
 
         # We enforce a limit to avoid burning out our connection pool.
         if multiplexed and self._max_in_flight_multiplexed is not None:
@@ -898,9 +900,7 @@ class HTTPAdapter(BaseAdapter):
             proxies=proxies,
         )
 
-        chunked = not (
-            bool(request.body) is False or "Content-Length" in request.headers
-        )
+        chunked = not (bool(request.body) is False or "Content-Length" in request.headers)
 
         if isinstance(timeout, tuple):
             try:
@@ -932,9 +932,7 @@ class HTTPAdapter(BaseAdapter):
             else:
                 implementation = None
 
-            extension = wrap_extension_for_http(
-                load_extension(scheme, implementation=implementation)
-            )()
+            extension = wrap_extension_for_http(load_extension(scheme, implementation=implementation))()
 
         def early_response_hook(early_response: BaseHTTPResponse) -> None:
             nonlocal on_early_response
@@ -956,9 +954,7 @@ class HTTPAdapter(BaseAdapter):
                 chunked=chunked,
                 on_post_connection=on_post_connection,
                 on_upload_body=on_upload_body,
-                on_early_response=early_response_hook
-                if on_early_response is not None
-                else None,
+                on_early_response=early_response_hook if on_early_response is not None else None,
                 extension=extension,
                 multiplexed=multiplexed,
             )
@@ -1017,9 +1013,7 @@ class HTTPAdapter(BaseAdapter):
 
         return self.build_response(request, resp_or_promise)
 
-    def _future_handler(
-        self, response: Response, low_resp: BaseHTTPResponse
-    ) -> Response | None:
+    def _future_handler(self, response: Response, low_resp: BaseHTTPResponse) -> Response | None:
         stream: bool = response._promise.get_parameter("niquests_is_stream")  # type: ignore[assignment]
         start: float = response._promise.get_parameter("niquests_start")  # type: ignore[assignment]
 
@@ -1030,9 +1024,7 @@ class HTTPAdapter(BaseAdapter):
         )
         max_redirect: int = response._promise.get_parameter("niquests_max_redirects")  # type: ignore[assignment]
         redirect_count: int = response._promise.get_parameter("niquests_redirect_count")  # type: ignore[assignment]
-        kwargs: typing.MutableMapping[str, typing.Any] = (
-            response._promise.get_parameter("niquests_kwargs")  # type: ignore[assignment]
-        )
+        kwargs: typing.MutableMapping[str, typing.Any] = response._promise.get_parameter("niquests_kwargs")  # type: ignore[assignment]
 
         # This mark the response as no longer "lazy"
         response.raw = low_resp
@@ -1065,20 +1057,14 @@ class HTTPAdapter(BaseAdapter):
         extract_cookies_to_jar(response.cookies, req, low_resp)
         extract_cookies_to_jar(session_cookies, req, low_resp)
 
-        promise_ctx_backup = {
-            k: v
-            for k, v in response_promise._parameters.items()
-            if k.startswith("niquests_")
-        }
+        promise_ctx_backup = {k: v for k, v in response_promise._parameters.items() if k.startswith("niquests_")}
 
         if allow_redirects:
             next_request = response._resolve_redirect(response, req)
             redirect_count += 1
 
             if redirect_count > max_redirect + 1:
-                raise TooManyRedirects(
-                    f"Exceeded {max_redirect} redirects", request=next_request
-                )
+                raise TooManyRedirects(f"Exceeded {max_redirect} redirects", request=next_request)
 
             if next_request:
                 del self._promises[response_promise.uid]
@@ -1096,9 +1082,7 @@ class HTTPAdapter(BaseAdapter):
                         and kwargs["verify"]
                         and is_ocsp_capable(conn_info)
                     ):
-                        strict_ocsp_enabled: bool = (
-                            os.environ.get("NIQUESTS_STRICT_OCSP", "0") != "0"
-                        )
+                        strict_ocsp_enabled: bool = os.environ.get("NIQUESTS_STRICT_OCSP", "0") != "0"
 
                         try:
                             from .extensions._ocsp import verify as ocsp_verify
@@ -1110,9 +1094,7 @@ class HTTPAdapter(BaseAdapter):
                                 strict_ocsp_enabled,
                                 0.2 if not strict_ocsp_enabled else 1.0,
                                 kwargs["proxies"],
-                                self._resolver
-                                if isinstance(self._resolver, BaseResolver)
-                                else None,
+                                self._resolver if isinstance(self._resolver, BaseResolver) else None,
                                 self._happy_eyeballs,
                             )
 
@@ -1134,9 +1116,7 @@ class HTTPAdapter(BaseAdapter):
                 if "niquests_origin_response" not in promise_ctx_backup:
                     promise_ctx_backup["niquests_origin_response"] = response
 
-                promise_ctx_backup["niquests_origin_response"].history.append(
-                    next_promise
-                )
+                promise_ctx_backup["niquests_origin_response"].history.append(next_promise)
 
                 promise_ctx_backup["niquests_start"] = preferred_clock()
                 promise_ctx_backup["niquests_redirect_count"] = redirect_count
@@ -1459,9 +1439,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             self.max_retries = urllib3_ensure_type(max_retries)  # type: ignore[type-var]
         else:
             if max_retries < 0:
-                raise ValueError(
-                    "configured retries count is invalid. you must specify a positive or zero integer value."
-                )
+                raise ValueError("configured retries count is invalid. you must specify a positive or zero integer value.")
             self.max_retries = Retry.from_int(max_retries)
             # Kept for backward compatibility.
             if max_retries == 0:
@@ -1585,9 +1563,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             **pool_kwargs,
         )
 
-    def proxy_manager_for(
-        self, proxy: str, **proxy_kwargs: typing.Any
-    ) -> AsyncProxyManager:
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: typing.Any) -> AsyncProxyManager:
         """Return urllib3 AsyncProxyManager for the given proxy.
 
         This method should not be called from user code, and is only
@@ -1693,10 +1669,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                             cert_loc = cert_loc.decode()
 
                     if isinstance(cert_loc, str) and not os.path.exists(cert_loc):
-                        raise OSError(
-                            f"Could not find a suitable TLS CA certificate bundle, "
-                            f"invalid path: {cert_loc}"
-                        )
+                        raise OSError(f"Could not find a suitable TLS CA certificate bundle, invalid path: {cert_loc}")
 
                 if not assert_fingerprint:
                     if conn.cert_reqs != "CERT_REQUIRED":
@@ -1762,20 +1735,13 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                 conn.key_file = None
                 conn.key_password = None
             if conn.cert_file and not os.path.exists(conn.cert_file):
-                raise OSError(
-                    f"Could not find the TLS certificate file, "
-                    f"invalid path: {conn.cert_file}"
-                )
+                raise OSError(f"Could not find the TLS certificate file, invalid path: {conn.cert_file}")
             if conn.key_file and not os.path.exists(conn.key_file):
-                raise OSError(
-                    f"Could not find the TLS key file, invalid path: {conn.key_file}"
-                )
+                raise OSError(f"Could not find the TLS key file, invalid path: {conn.key_file}")
 
         return need_reboot_conn
 
-    def build_response(
-        self, req: PreparedRequest, resp: BaseAsyncHTTPResponse | ResponsePromise
-    ) -> AsyncResponse:
+    def build_response(self, req: PreparedRequest, resp: BaseAsyncHTTPResponse | ResponsePromise) -> AsyncResponse:
         """Builds a :class:`Response <requests.Response>` object from a urllib3
         response. This should not be called from user code, and is only exposed
         for use when subclassing the
@@ -1833,10 +1799,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             proxy = prepend_scheme_if_needed(proxy, "http")
             proxy_url = parse_url(proxy)
             if not proxy_url.host:
-                raise InvalidProxyURL(
-                    "Please check proxy URL. It is malformed "
-                    "and could be missing the host."
-                )
+                raise InvalidProxyURL("Please check proxy URL. It is malformed and could be missing the host.")
             proxy_manager = self.proxy_manager_for(proxy)
             conn = await proxy_manager.connection_from_url(url)
         else:
@@ -1929,14 +1892,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         verify: TLSVerifyType = True,
         cert: TLSClientCertType | None = None,
         proxies: ProxyType | None = None,
-        on_post_connection: typing.Callable[[typing.Any], typing.Awaitable[None]]
-        | None = None,
-        on_upload_body: typing.Callable[
-            [int, int | None, bool, bool], typing.Awaitable[None]
-        ]
-        | None = None,
-        on_early_response: typing.Callable[[Response], typing.Awaitable[None]]
-        | None = None,
+        on_post_connection: typing.Callable[[typing.Any], typing.Awaitable[None]] | None = None,
+        on_upload_body: typing.Callable[[int, int | None, bool, bool], typing.Awaitable[None]] | None = None,
+        on_early_response: typing.Callable[[Response], typing.Awaitable[None]] | None = None,
         multiplexed: bool = False,
     ) -> AsyncResponse:
         """Sends PreparedRequest object. Returns Response object.
@@ -1957,11 +1915,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         :param multiplexed: Determine if request shall be transmitted by leveraging the multiplexed aspect of the protocol
             if available. Return a lazy instance of Response pending its retrieval.
         """
-        assert (
-            request.url is not None
-            and request.headers is not None
-            and request.method is not None
-        ), "Tried to send a non-initialized PreparedRequest"
+        assert request.url is not None and request.headers is not None and request.method is not None, (
+            "Tried to send a non-initialized PreparedRequest"
+        )
 
         # We enforce a limit to avoid burning out our connection pool.
         if multiplexed and self._max_in_flight_multiplexed is not None:
@@ -1996,9 +1952,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             proxies=proxies,
         )
 
-        chunked = not (
-            bool(request.body) is False or "Content-Length" in request.headers
-        )
+        chunked = not (bool(request.body) is False or "Content-Length" in request.headers)
 
         if isinstance(timeout, tuple):
             try:
@@ -2030,9 +1984,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             else:
                 implementation = None
 
-            extension = async_wrap_extension_for_http(
-                async_load_extension(scheme, implementation=implementation)
-            )()
+            extension = async_wrap_extension_for_http(async_load_extension(scheme, implementation=implementation))()
 
         async def early_response_hook(early_response: BaseAsyncHTTPResponse) -> None:
             nonlocal on_early_response
@@ -2054,9 +2006,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                 chunked=chunked,
                 on_post_connection=on_post_connection,
                 on_upload_body=on_upload_body,
-                on_early_response=early_response_hook
-                if on_early_response is not None
-                else None,
+                on_early_response=early_response_hook if on_early_response is not None else None,
                 extension=extension,
                 multiplexed=multiplexed,
             )
@@ -2131,9 +2081,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         )
         max_redirect: int = response._promise.get_parameter("niquests_max_redirects")  # type: ignore[assignment]
         redirect_count: int = response._promise.get_parameter("niquests_redirect_count")  # type: ignore[assignment]
-        kwargs: typing.MutableMapping[str, typing.Any] = (
-            response._promise.get_parameter("niquests_kwargs")  # type: ignore[assignment]
-        )
+        kwargs: typing.MutableMapping[str, typing.Any] = response._promise.get_parameter("niquests_kwargs")  # type: ignore[assignment]
 
         # This mark the response as no longer "lazy"
         response.raw = low_resp
@@ -2166,20 +2114,14 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         extract_cookies_to_jar(response.cookies, req, low_resp)
         extract_cookies_to_jar(session_cookies, req, low_resp)
 
-        promise_ctx_backup = {
-            k: v
-            for k, v in response_promise._parameters.items()
-            if k.startswith("niquests_")
-        }
+        promise_ctx_backup = {k: v for k, v in response_promise._parameters.items() if k.startswith("niquests_")}
 
         if allow_redirects:
             next_request = await response._resolve_redirect(response, req)
             redirect_count += 1
 
             if redirect_count > max_redirect + 1:
-                raise TooManyRedirects(
-                    f"Exceeded {max_redirect} redirects", request=next_request
-                )
+                raise TooManyRedirects(f"Exceeded {max_redirect} redirects", request=next_request)
 
             if next_request:
                 del self._promises[response_promise.uid]
@@ -2204,18 +2146,14 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                         except ImportError:
                             pass
                         else:
-                            strict_ocsp_enabled: bool = (
-                                os.environ.get("NIQUESTS_STRICT_OCSP", "0") != "0"
-                            )
+                            strict_ocsp_enabled: bool = os.environ.get("NIQUESTS_STRICT_OCSP", "0") != "0"
 
                             await async_ocsp_verify(
                                 next_request,
                                 strict_ocsp_enabled,
                                 0.2 if not strict_ocsp_enabled else 1.0,
                                 kwargs["proxies"],
-                                self._resolver
-                                if isinstance(self._resolver, AsyncBaseResolver)
-                                else None,
+                                self._resolver if isinstance(self._resolver, AsyncBaseResolver) else None,
                                 self._happy_eyeballs,
                             )
 
@@ -2237,9 +2175,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                 if "niquests_origin_response" not in promise_ctx_backup:
                     promise_ctx_backup["niquests_origin_response"] = response
 
-                promise_ctx_backup["niquests_origin_response"].history.append(
-                    next_promise
-                )
+                promise_ctx_backup["niquests_origin_response"].history.append(next_promise)
 
                 promise_ctx_backup["niquests_start"] = preferred_clock()
                 promise_ctx_backup["niquests_redirect_count"] = redirect_count
@@ -2315,9 +2251,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
 
         return None
 
-    async def gather(
-        self, *responses: Response | AsyncResponse, max_fetch: int | None = None
-    ) -> None:
+    async def gather(self, *responses: Response | AsyncResponse, max_fetch: int | None = None) -> None:
         if not self._promises:
             return
 
@@ -2393,15 +2327,11 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
                     max_fetch -= 1
 
                 assert (
-                    low_resp._fp is not None
-                    and hasattr(low_resp._fp, "from_promise")
-                    and low_resp._fp.from_promise is not None
+                    low_resp._fp is not None and hasattr(low_resp._fp, "from_promise") and low_resp._fp.from_promise is not None
                 )
 
                 response = (
-                    self._promises[low_resp._fp.from_promise.uid]
-                    if low_resp._fp.from_promise.uid in self._promises
-                    else None
+                    self._promises[low_resp._fp.from_promise.uid] if low_resp._fp.from_promise.uid in self._promises else None
                 )
 
                 if response is None:

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -59,7 +59,8 @@ def request(
 ) -> Response:
     """Constructs and sends a :class:`Request <Request>`.
 
-    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``,
+        or ``DELETE``.
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
         in the query string for the :class:`Request`.
@@ -68,7 +69,8 @@ def request(
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
         ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
         or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
         defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
@@ -77,7 +79,8 @@ def request(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -85,7 +88,8 @@ def request(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -102,9 +106,7 @@ def request(
     # By using the 'with' statement we are sure the session is closed, thus we
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
-    with sessions.Session(
-        quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries
-    ) as session:
+    with sessions.Session(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries) as session:
         return session.request(
             method=method,
             url=url,
@@ -155,7 +157,8 @@ def get(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -163,7 +166,8 @@ def get(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -217,7 +221,8 @@ def options(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -225,7 +230,8 @@ def options(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -280,7 +286,8 @@ def head(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -288,7 +295,8 @@ def head(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -344,7 +352,8 @@ def post(
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
         ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
         or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
         defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
@@ -353,7 +362,8 @@ def post(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -361,7 +371,8 @@ def post(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -419,7 +430,8 @@ def put(
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
         ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
         or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
         defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
@@ -428,7 +440,8 @@ def put(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -436,7 +449,8 @@ def put(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -494,7 +508,8 @@ def patch(
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
         ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
         or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
         defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
@@ -503,7 +518,8 @@ def patch(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -511,7 +527,8 @@ def patch(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
@@ -568,7 +585,8 @@ def delete(
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     ::param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,
@@ -576,7 +594,8 @@ def delete(
             Defaults to ``True``.
             It is also possible to put the certificates (directly) in a string or bytes.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
     :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
     :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
             Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.

--- a/src/niquests/auth.py
+++ b/src/niquests/auth.py
@@ -220,10 +220,7 @@ class HTTPDigestAuth(AuthBase):
         self._thread_local.last_nonce = nonce
 
         # XXX should the partial digests be encoded too?
-        base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
-            f'uri="{path}", response="{respdig}"'
-        )
+        base = f'username="{self.username}", realm="{realm}", nonce="{nonce}", uri="{path}", response="{respdig}"'
         if opaque:
             base += f', opaque="{opaque}"'
         if algorithm:
@@ -272,9 +269,7 @@ class HTTPDigestAuth(AuthBase):
             extract_cookies_to_jar(prep._cookies, r.request, r.raw)
             prep.prepare_cookies(prep._cookies)
 
-            prep.headers["Authorization"] = self.build_digest_header(
-                prep.method, prep.url
-            )
+            prep.headers["Authorization"] = self.build_digest_header(prep.method, prep.url)
             _r = r.connection.send(prep, **kwargs)
             _r.history.append(r)
             _r.request = prep

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -110,9 +110,7 @@ class MockRequest:
 
     def add_header(self, key, val):
         """cookiejar has no legitimate use for this method; add it back if you find one."""
-        raise NotImplementedError(
-            "Cookie headers should be added with add_unredirected_header()"
-        )
+        raise NotImplementedError("Cookie headers should be added with add_unredirected_header()")
 
     def add_unredirected_header(self, name, value):
         self._new_headers[name] = value
@@ -166,9 +164,7 @@ def extract_cookies_to_jar(
     :param response: urllib3.HTTPResponse object
     """
     if request is None or response is None:
-        raise ValueError(
-            "Attempt to extract cookie from undefined request and/or response"
-        )
+        raise ValueError("Attempt to extract cookie from undefined request and/or response")
 
     if not (hasattr(response, "_original_response") and response._original_response):
         return
@@ -233,9 +229,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
     .. warning:: dictionary operations that are normally O(1) may be O(n).
     """
 
-    def __init__(
-        self, policy: cookielib.CookiePolicy | None = None, thread_free: bool = False
-    ):
+    def __init__(self, policy: cookielib.CookiePolicy | None = None, thread_free: bool = False):
         super().__init__(policy=policy or CookiePolicyLocalhostBypass())
         if thread_free:
             from .structures import DummyLock
@@ -261,9 +255,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
         """
         # support client code that unsets cookies by assignment of a None value:
         if value is None:
-            remove_cookie_by_name(
-                self, name, domain=kwargs.get("domain"), path=kwargs.get("path")
-            )
+            remove_cookie_by_name(self, name, domain=kwargs.get("domain"), path=kwargs.get("path"))
             return
 
         if isinstance(value, Morsel):
@@ -353,18 +345,14 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
             domains.append(cookie.domain)
         return False  # there is only one domain in jar
 
-    def get_dict(
-        self, domain: str | None = None, path: str | None = None
-    ) -> dict[str, str | None]:
+    def get_dict(self, domain: str | None = None, path: str | None = None) -> dict[str, str | None]:
         """Takes as an argument an optional domain and path and returns a plain
         old Python dict of name-value pairs of cookies that meet the
         requirements.
         """
         dictionary = {}
         for cookie in iter(self):
-            if (domain is None or cookie.domain == domain) and (
-                path is None or cookie.path == path
-            ):
+            if (domain is None or cookie.domain == domain) and (path is None or cookie.path == path):
                 dictionary[cookie.name] = cookie.value
         return dictionary
 
@@ -397,11 +385,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
         remove_cookie_by_name(self, name)
 
     def set_cookie(self, cookie, *args, **kwargs):
-        if (
-            hasattr(cookie.value, "startswith")
-            and cookie.value.startswith('"')
-            and cookie.value.endswith('"')
-        ):
+        if hasattr(cookie.value, "startswith") and cookie.value.startswith('"') and cookie.value.endswith('"'):
             cookie.value = cookie.value.replace('\\"', "")
         return super().set_cookie(cookie, *args, **kwargs)
 
@@ -452,9 +436,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
                     if path is None or cookie.path == path:
                         if toReturn is not None:
                             # if there are multiple cookies that meet passed in criteria
-                            raise CookieConflictError(
-                                f"There are multiple cookies with name, {name!r}"
-                            )
+                            raise CookieConflictError(f"There are multiple cookies with name, {name!r}")
                         # we will eventually return this as long as no cookie conflict
                         toReturn = cookie.value
 
@@ -526,9 +508,7 @@ def create_cookie(name, value, **kwargs):
 
     badargs = set(kwargs) - set(result)
     if badargs:
-        raise TypeError(
-            f"create_cookie() got unexpected keyword arguments: {list(badargs)}"
-        )
+        raise TypeError(f"create_cookie() got unexpected keyword arguments: {list(badargs)}")
 
     result.update(kwargs)
     result["port_specified"] = bool(result["port"])

--- a/src/niquests/exceptions.py
+++ b/src/niquests/exceptions.py
@@ -34,11 +34,7 @@ class RequestException(IOError):
         response = kwargs.pop("response", None)
         self.response = response
         self.request = kwargs.pop("request", None)
-        if (
-            self.response is not None
-            and not self.request
-            and hasattr(self.response, "request")
-        ):
+        if self.response is not None and not self.request and hasattr(self.response, "request"):
             self.request = self.response.request
         super().__init__(*args, **kwargs)
 

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -12,35 +12,46 @@ from hashlib import sha256
 from random import randint
 
 from qh3._hazmat import (
+    Certificate,
+    OCSPCertStatus,
     OCSPRequest,
     OCSPResponse,
     OCSPResponseStatus,
-    OCSPCertStatus,
-    Certificate,
 )
 
 from .._compat import HAS_LEGACY_URLLIB3
 
 if HAS_LEGACY_URLLIB3 is False:
     from urllib3 import ConnectionInfo
-    from urllib3.exceptions import SecurityWarning
-    from urllib3.util.url import parse_url
     from urllib3.contrib.resolver._async import AsyncBaseResolver
     from urllib3.contrib.ssa import AsyncSocket
+    from urllib3.exceptions import SecurityWarning
+    from urllib3.util.url import parse_url
 else:  # Defensive: tested in separate/isolated CI
     from urllib3_future import ConnectionInfo  # type: ignore[assignment]
+    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
+        AsyncBaseResolver,
+    )
+    from urllib3_future.contrib.ssa import AsyncSocket  # type: ignore[assignment]
     from urllib3_future.exceptions import SecurityWarning  # type: ignore[assignment]
     from urllib3_future.util.url import parse_url  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import AsyncBaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.ssa import AsyncSocket  # type: ignore[assignment]
 
 from .._typing import ProxyType
 from ..exceptions import RequestException, SSLError
 from ..models import PreparedRequest
+from ._ocsp import (
+    _parse_x509_der_cached,
+    _str_fingerprint_of,
+    readable_revocation_reason,
+)
 from ._picotls import (
     ALERT,
     CHANGE_CIPHER,
     HANDSHAKE,
+    PicoTLSException,
+    async_recv_tls,
+    async_recv_tls_and_decrypt,
+    async_send_tls,
     derive_secret,
     gen_client_hello,
     handle_encrypted_extensions,
@@ -48,21 +59,10 @@ from ._picotls import (
     handle_server_hello,
     multiply_num_on_ec_point,
     num_to_bytes,
-    async_recv_tls,
-    async_recv_tls_and_decrypt,
-    async_send_tls,
-    PicoTLSException,
-)
-from ._ocsp import (
-    _str_fingerprint_of,
-    readable_revocation_reason,
-    _parse_x509_der_cached,
 )
 
 
-async def _ask_nicely_for_issuer(
-    hostname: str, dst_address: tuple[str, int], timeout: int | float = 0.2
-) -> Certificate | None:
+async def _ask_nicely_for_issuer(hostname: str, dst_address: tuple[str, int], timeout: int | float = 0.2) -> Certificate | None:
     """When encountering a problem in development, one should always say that there is many solutions.
     From dirtiest to the cleanest, not always known but with progressive effort, we'll eventually land at the cleanest.
 
@@ -94,9 +94,7 @@ async def _ask_nicely_for_issuer(
         our_ecdh_privkey, SECP256R1_G[0], SECP256R1_G[1], SECP256R1_A, SECP256R1_P
     )
 
-    client_hello = gen_client_hello(
-        hostname, client_random, our_ecdh_pubkey_x, our_ecdh_pubkey_y
-    )
+    client_hello = gen_client_hello(hostname, client_random, our_ecdh_pubkey_x, our_ecdh_pubkey_y)
 
     await async_send_tls(sock, HANDSHAKE, client_hello)
 
@@ -129,24 +127,16 @@ async def _ask_nicely_for_issuer(
     our_secret = num_to_bytes(our_secret_point_x, 32)
 
     early_secret = hmac.new(b"", b"\x00" * 32, sha256).digest()
-    preextractsec = derive_secret(
-        b"derived", key=early_secret, data=sha256(b"").digest(), hash_len=32
-    )
+    preextractsec = derive_secret(b"derived", key=early_secret, data=sha256(b"").digest(), hash_len=32)
     handshake_secret = hmac.new(preextractsec, our_secret, sha256).digest()
     hello_hash = sha256(client_hello + server_hello).digest()
-    server_hs_secret = derive_secret(
-        b"s hs traffic", key=handshake_secret, data=hello_hash, hash_len=32
-    )
-    server_write_key = derive_secret(
-        b"key", key=server_hs_secret, data=b"", hash_len=16
-    )
+    server_hs_secret = derive_secret(b"s hs traffic", key=handshake_secret, data=hello_hash, hash_len=32)
+    server_write_key = derive_secret(b"key", key=server_hs_secret, data=b"", hash_len=16)
     server_write_iv = derive_secret(b"iv", key=server_hs_secret, data=b"", hash_len=12)
 
     server_seq_num = 0
 
-    rec_type, encrypted_extensions = await async_recv_tls_and_decrypt(
-        sock, server_write_key, server_write_iv, server_seq_num
-    )
+    rec_type, encrypted_extensions = await async_recv_tls_and_decrypt(sock, server_write_key, server_write_iv, server_seq_num)
 
     if not rec_type == HANDSHAKE:
         sock.close()
@@ -157,9 +147,7 @@ async def _ask_nicely_for_issuer(
     remaining_bytes = handle_encrypted_extensions(encrypted_extensions)
 
     if not remaining_bytes:
-        rec_type, server_cert = await async_recv_tls_and_decrypt(
-            sock, server_write_key, server_write_iv, server_seq_num
-        )
+        rec_type, server_cert = await async_recv_tls_and_decrypt(sock, server_write_key, server_write_iv, server_seq_num)
     else:
         rec_type, server_cert = rec_type, remaining_bytes
 
@@ -207,11 +195,7 @@ class InMemoryRevocationStatus:
         }
 
     def __setstate__(self, state: dict[str, typing.Any]) -> None:
-        if (
-            "_store" not in state
-            or "_issuers_map" not in state
-            or "_max_size" not in state
-        ):
+        if "_store" not in state or "_issuers_map" not in state or "_max_size" not in state:
             raise OSError("unrecoverable state for InMemoryRevocationStatus")
 
         self.hold = False
@@ -243,9 +227,7 @@ class InMemoryRevocationStatus:
         return len(self._store)
 
     @asynccontextmanager
-    async def lock(
-        self, peer_certificate: Certificate
-    ) -> typing.AsyncGenerator[None, None]:
+    async def lock(self, peer_certificate: Certificate) -> typing.AsyncGenerator[None, None]:
         fingerprint: str = _str_fingerprint_of(peer_certificate)
 
         if fingerprint not in self._semaphores:
@@ -280,10 +262,7 @@ class InMemoryRevocationStatus:
         cached_response = self._store[fingerprint]
 
         if cached_response.certificate_status == OCSPCertStatus.GOOD:
-            if (
-                cached_response.next_update
-                and datetime.datetime.now().timestamp() >= cached_response.next_update
-            ):
+            if cached_response.next_update and datetime.datetime.now().timestamp() >= cached_response.next_update:
                 del self._store[fingerprint]
                 return None
             return cached_response
@@ -345,11 +324,7 @@ async def verify(
     conn_info: ConnectionInfo | None = r.conn_info
 
     # we can't do anything in that case.
-    if (
-        conn_info is None
-        or conn_info.certificate_der is None
-        or conn_info.certificate_dict is None
-    ):
+    if conn_info is None or conn_info.certificate_der is None or conn_info.certificate_dict is None:
         return
 
     endpoints: list[str] = [  # type: ignore
@@ -395,7 +370,7 @@ async def verify(
                         (
                             f"Unable to establish a secure connection to {r.url} because the certificate has been revoked "
                             f"by issuer ({readable_revocation_reason(cached_response.revocation_reason) or 'unspecified'}). "
-                            'You should avoid trying to request anything from it as the remote has been compromised. ',
+                            "You should avoid trying to request anything from it as the remote has been compromised. ",
                             "See https://niquests.readthedocs.io/en/latest/user/advanced.html#ocsp-or-certificate-revocation "
                             "for more information.",
                         )
@@ -415,9 +390,7 @@ async def verify(
 
         from .._async import AsyncSession
 
-        async with AsyncSession(
-            resolver=resolver, happy_eyeballs=happy_eyeballs
-        ) as session:
+        async with AsyncSession(resolver=resolver, happy_eyeballs=happy_eyeballs) as session:
             session.trust_env = False
             if proxies:
                 session.proxies = proxies
@@ -441,10 +414,7 @@ async def verify(
 
                         url_parsed = parse_url(r.url)
 
-                        if (
-                            url_parsed.hostname is None
-                            or conn_info.destination_address is None
-                        ):
+                        if url_parsed.hostname is None or conn_info.destination_address is None:
                             raise ValueError
 
                         if not proxies:
@@ -478,36 +448,21 @@ async def verify(
 
                 if issuer_certificate is None and hint_ca_issuers:
                     try:
-                        raw_intermediary_response = await session.get(
-                            hint_ca_issuers[0]
-                        )
+                        raw_intermediary_response = await session.get(hint_ca_issuers[0])
                     except RequestException:
                         pass
                     else:
-                        if (
-                            raw_intermediary_response.status_code
-                            and 300 > raw_intermediary_response.status_code >= 200
-                        ):
+                        if raw_intermediary_response.status_code and 300 > raw_intermediary_response.status_code >= 200:
                             raw_intermediary_content = raw_intermediary_response.content
 
                             if raw_intermediary_content is not None:
                                 # binary DER
-                                if (
-                                    b"-----BEGIN CERTIFICATE-----"
-                                    not in raw_intermediary_content
-                                ):
-                                    issuer_certificate = Certificate(
-                                        raw_intermediary_content
-                                    )
+                                if b"-----BEGIN CERTIFICATE-----" not in raw_intermediary_content:
+                                    issuer_certificate = Certificate(raw_intermediary_content)
                                 # b64 PEM
-                                elif (
-                                    b"-----BEGIN CERTIFICATE-----"
-                                    in raw_intermediary_content
-                                ):
+                                elif b"-----BEGIN CERTIFICATE-----" in raw_intermediary_content:
                                     issuer_certificate = Certificate(
-                                        ssl.PEM_cert_to_DER_cert(
-                                            raw_intermediary_content.decode()
-                                        )
+                                        ssl.PEM_cert_to_DER_cert(raw_intermediary_content.decode())
                                     )
 
                 # Well! We're out of luck. No further should we go.
@@ -528,9 +483,7 @@ async def verify(
                 issuer_certificate = Certificate(conn_info.issuer_certificate_der)
 
             try:
-                req = OCSPRequest(
-                    peer_certificate.public_bytes(), issuer_certificate.public_bytes()
-                )
+                req = OCSPRequest(peer_certificate.public_bytes(), issuer_certificate.public_bytes())
             except ValueError:
                 if strict:
                     warnings.warn(
@@ -562,10 +515,7 @@ async def verify(
                     )
                 return
 
-            if (
-                ocsp_http_response.status_code
-                and 300 > ocsp_http_response.status_code >= 200
-            ):
+            if ocsp_http_response.status_code and 300 > ocsp_http_response.status_code >= 200:
                 if ocsp_http_response.content is None:
                     return
 

--- a/src/niquests/extensions/_picotls.py
+++ b/src/niquests/extensions/_picotls.py
@@ -350,24 +350,14 @@ def gen_client_hello(hostname, client_random, ecdh_pubkey_x, ecdh_pubkey_y):
     hostname_item_length = num_to_bytes(len(hostname) + 3, 2)
     hostname_length = num_to_bytes(len(hostname), 2)
 
-    hostname_extension = (
-        hostname_prefix
-        + hostname_list_length
-        + hostname_item_length
-        + b"\x00"
-        + hostname_length
-        + hostname
-    )
+    hostname_extension = hostname_prefix + hostname_list_length + hostname_item_length + b"\x00" + hostname_length + hostname
 
     supported_versions = b"\x00\x2b"
     supported_versions_length = b"\x00\x03"
     another_supported_versions_length = b"\x02"
     tls1_3_version = b"\x03\x04"
     supported_version_extension = (
-        supported_versions
-        + supported_versions_length
-        + another_supported_versions_length
-        + tls1_3_version
+        supported_versions + supported_versions_length + another_supported_versions_length + tls1_3_version
     )
 
     signature_algos = b"\x00\x0d"
@@ -388,28 +378,16 @@ def gen_client_hello(hostname, client_random, ecdh_pubkey_x, ecdh_pubkey_y):
     supported_groups_length = b"\x00\x04"
     another_supported_groups_length = b"\x00\x02"
     secp256r1_group = b"\x00\x17"
-    supported_groups_extension = (
-        supported_groups
-        + supported_groups_length
-        + another_supported_groups_length
-        + secp256r1_group
-    )
+    supported_groups_extension = supported_groups + supported_groups_length + another_supported_groups_length + secp256r1_group
 
-    ecdh_pubkey = (
-        b"\x04" + num_to_bytes(ecdh_pubkey_x, 32) + num_to_bytes(ecdh_pubkey_y, 32)
-    )
+    ecdh_pubkey = b"\x04" + num_to_bytes(ecdh_pubkey_x, 32) + num_to_bytes(ecdh_pubkey_y, 32)
 
     key_share = b"\x00\x33"
     key_share_length = num_to_bytes(len(ecdh_pubkey) + 4 + 2, 2)
     another_key_share_length = num_to_bytes(len(ecdh_pubkey) + 4, 2)
     key_exchange_len = num_to_bytes(len(ecdh_pubkey), 2)
     key_share_extension = (
-        key_share
-        + key_share_length
-        + another_key_share_length
-        + secp256r1_group
-        + key_exchange_len
-        + ecdh_pubkey
+        key_share + key_share_length + another_key_share_length + secp256r1_group + key_exchange_len + ecdh_pubkey
     )
 
     extensions = (
@@ -460,12 +438,8 @@ def handle_server_hello(server_hello):
 
     # compression_method = server_hello[39 + session_id_len + 2 : 39 + session_id_len + 3]
 
-    extensions_length = bytes_to_num(
-        server_hello[39 + session_id_len + 3 : 39 + session_id_len + 3 + 2]
-    )
-    extensions = server_hello[
-        39 + session_id_len + 3 + 2 : 39 + session_id_len + 3 + 2 + extensions_length
-    ]
+    extensions_length = bytes_to_num(server_hello[39 + session_id_len + 3 : 39 + session_id_len + 3 + 2])
+    extensions = server_hello[39 + session_id_len + 3 + 2 : 39 + session_id_len + 3 + 2 + extensions_length]
 
     public_ec_key = b""
     ptr = 0
@@ -517,20 +491,12 @@ def ghash(h, data):
 
 def derive_secret(label, key, data, hash_len):
     full_label = b"tls13 " + label
-    packed_data = (
-        num_to_bytes(hash_len, 2)
-        + num_to_bytes(len(full_label), 1)
-        + full_label
-        + num_to_bytes(len(data), 1)
-        + data
-    )
+    packed_data = num_to_bytes(hash_len, 2) + num_to_bytes(len(full_label), 1) + full_label + num_to_bytes(len(data), 1) + data
 
     secret = bytearray()
     i = 1
     while len(secret) < hash_len:
-        secret += hmac.new(
-            key, secret[-32:] + packed_data + num_to_bytes(i, 1), sha256
-        ).digest()
+        secret += hmac.new(key, secret[-32:] + packed_data + num_to_bytes(i, 1), sha256).digest()
         i += 1
     return bytes(secret[:hash_len])
 
@@ -589,14 +555,10 @@ def aes128_encrypt(key, plaintext):
     result = [
         bytes(
             [
-                AES_SBOX[(t[(i + 0) % 4] >> 8 * 3) & 0xFF]
-                ^ (enc_keys[-1][i] >> 8 * 3) & 0xFF,
-                AES_SBOX[(t[(i + 1) % 4] >> 8 * 2) & 0xFF]
-                ^ (enc_keys[-1][i] >> 8 * 2) & 0xFF,
-                AES_SBOX[(t[(i + 2) % 4] >> 8 * 1) & 0xFF]
-                ^ (enc_keys[-1][i] >> 8 * 1) & 0xFF,
-                AES_SBOX[(t[(i + 3) % 4] >> 8 * 0) & 0xFF]
-                ^ (enc_keys[-1][i] >> 8 * 0) & 0xFF,
+                AES_SBOX[(t[(i + 0) % 4] >> 8 * 3) & 0xFF] ^ (enc_keys[-1][i] >> 8 * 3) & 0xFF,
+                AES_SBOX[(t[(i + 1) % 4] >> 8 * 2) & 0xFF] ^ (enc_keys[-1][i] >> 8 * 2) & 0xFF,
+                AES_SBOX[(t[(i + 2) % 4] >> 8 * 1) & 0xFF] ^ (enc_keys[-1][i] >> 8 * 1) & 0xFF,
+                AES_SBOX[(t[(i + 3) % 4] >> 8 * 0) & 0xFF] ^ (enc_keys[-1][i] >> 8 * 0) & 0xFF,
             ]
         )
         for i in range(4)
@@ -704,9 +666,7 @@ def recv_tls_and_decrypt(s, key, nonce, seq_num):
     if rec_type != APPLICATION_DATA:
         raise PicoTLSException
 
-    msg_type, msg = do_authenticated_decryption(
-        key, nonce, seq_num, APPLICATION_DATA, encrypted_msg
-    )
+    msg_type, msg = do_authenticated_decryption(key, nonce, seq_num, APPLICATION_DATA, encrypted_msg)
     return msg_type, msg
 
 
@@ -715,9 +675,7 @@ async def async_recv_tls_and_decrypt(s, key, nonce, seq_num):
     if rec_type != APPLICATION_DATA:
         raise PicoTLSException
 
-    msg_type, msg = do_authenticated_decryption(
-        key, nonce, seq_num, APPLICATION_DATA, encrypted_msg
-    )
+    msg_type, msg = do_authenticated_decryption(key, nonce, seq_num, APPLICATION_DATA, encrypted_msg)
     return msg_type, msg
 
 

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -15,14 +15,13 @@ import warnings
 from json import JSONDecodeError
 
 import charset_normalizer
-import jh2  # type: ignore
 import h11
 import idna
+import jh2  # type: ignore
 import wassima
 
-from . import RequestException, HTTPError
+from . import HTTPError, RequestException, Session
 from . import __version__ as niquests_version
-from . import Session
 from ._compat import HAS_LEGACY_URLLIB3
 
 if HAS_LEGACY_URLLIB3 is True:
@@ -58,9 +57,7 @@ except ImportError:
     wsproto = None  # type: ignore
 
 
-_IS_GIL_DISABLED: bool = (
-    hasattr(sys, "_is_gil_enabled") and sys._is_gil_enabled() is False
-)
+_IS_GIL_DISABLED: bool = hasattr(sys, "_is_gil_enabled") and sys._is_gil_enabled() is False
 
 
 def _implementation():
@@ -79,10 +76,10 @@ def _implementation():
     if implementation == "CPython":
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
-        implementation_version = "{}.{}.{}".format(
-            sys.pypy_version_info.major,  # type: ignore[attr-defined]
-            sys.pypy_version_info.minor,  # type: ignore[attr-defined]
-            sys.pypy_version_info.micro,  # type: ignore[attr-defined]
+        implementation_version = (
+            f"{sys.pypy_version_info.major}"  # type: ignore[attr-defined]
+            f".{sys.pypy_version_info.minor}"  # type: ignore[attr-defined]
+            f".{sys.pypy_version_info.micro}"  # type: ignore[attr-defined]
         )
         if sys.pypy_version_info.releaselevel != "final":  # type: ignore[attr-defined]
             implementation_version = "".join(
@@ -178,15 +175,13 @@ def check_update(package_name: str, actual_version: str) -> None:
         response = pypi_session.get(f"https://pypi.org/pypi/{package_name}/json")
         package_info = response.raise_for_status().json()
 
-        if (
-            isinstance(package_info, dict)
-            and "info" in package_info
-            and "version" in package_info["info"]
-        ):
+        if isinstance(package_info, dict) and "info" in package_info and "version" in package_info["info"]:
             if package_info["info"]["version"] != actual_version:
                 warnings.warn(
-                    f"You are using {package_name} {actual_version} and PyPI yield version ({package_info['info']['version']}) as the stable one. "
-                    f"We invite you to install this version as soon as possible. Run `python -m pip install {package_name} -U`.",
+                    f"You are using {package_name} {actual_version} and "
+                    f"PyPI yield version ({package_info['info']['version']}) as the stable one. "
+                    "We invite you to install this version as soon as possible. "
+                    f"Run `python -m pip install {package_name} -U`.",
                     UserWarning,
                 )
     except (RequestException, JSONDecodeError, HTTPError):

--- a/src/niquests/hooks.py
+++ b/src/niquests/hooks.py
@@ -9,9 +9,11 @@ Available hooks:
 ``pre_request``:
     The prepared request just got built. You may alter it prior to be sent through HTTP.
 ``pre_send``:
-    The prepared request got his ConnectionInfo injected. This event is triggered just after picking a live connection from the pool.
+    The prepared request got his ConnectionInfo injected.
+    This event is triggered just after picking a live connection from the pool.
 ``on_upload``:
-    Permit to monitor the upload progress of passed body. This event is triggered each time a block of data is transmitted to the remote peer.
+    Permit to monitor the upload progress of passed body.
+    This event is triggered each time a block of data is transmitted to the remote peer.
     Use this hook carefully as it may impact the overall performance.
 ``response``:
     The response generated from a Request.
@@ -24,10 +26,10 @@ import typing
 
 from ._typing import (
     _HV,
+    AsyncHookCallableType,
+    AsyncHookType,
     HookCallableType,
     HookType,
-    AsyncHookType,
-    AsyncHookCallableType,
 )
 
 HOOKS = [
@@ -43,16 +45,12 @@ def default_hooks() -> HookType[_HV]:
     return {event: [] for event in HOOKS}
 
 
-def dispatch_hook(
-    key: str, hooks: HookType[_HV] | None, hook_data: _HV, **kwargs: typing.Any
-) -> _HV:
+def dispatch_hook(key: str, hooks: HookType[_HV] | None, hook_data: _HV, **kwargs: typing.Any) -> _HV:
     """Dispatches a hook dictionary on a given piece of data."""
     if hooks is None:
         return hook_data
 
-    callables: list[HookCallableType[_HV]] | HookCallableType[_HV] | None = hooks.get(
-        key
-    )
+    callables: list[HookCallableType[_HV]] | HookCallableType[_HV] | None = hooks.get(key)
 
     if callables:
         if callable(callables):
@@ -68,18 +66,13 @@ def dispatch_hook(
     return hook_data
 
 
-async def async_dispatch_hook(
-    key: str, hooks: AsyncHookType[_HV] | None, hook_data: _HV, **kwargs: typing.Any
-) -> _HV:
+async def async_dispatch_hook(key: str, hooks: AsyncHookType[_HV] | None, hook_data: _HV, **kwargs: typing.Any) -> _HV:
     """Dispatches a hook dictionary on a given piece of data asynchronously."""
     if hooks is None:
         return hook_data
 
     callables: (
-        list[HookCallableType[_HV] | AsyncHookCallableType[_HV]]
-        | HookCallableType[_HV]
-        | AsyncHookCallableType[_HV]
-        | None
+        list[HookCallableType[_HV] | AsyncHookCallableType[_HV]] | HookCallableType[_HV] | AsyncHookCallableType[_HV] | None
     ) = hooks.get(key)
 
     if callables:

--- a/src/niquests/status_codes.py
+++ b/src/niquests/status_codes.py
@@ -117,14 +117,10 @@ def _init():
 
     def doc(code):
         names = ", ".join(f"``{n}``" for n in _codes[code])
-        return "* %d: %s" % (code, names)
+        return f"* {code}: {names}"
 
     global __doc__
-    __doc__ = (
-        __doc__ + "\n" + "\n".join(doc(code) for code in sorted(_codes))
-        if __doc__ is not None
-        else None
-    )
+    __doc__ = __doc__ + "\n" + "\n".join(doc(code) for code in sorted(_codes)) if __doc__ is not None else None
 
 
 _init()

--- a/src/niquests/structures.py
+++ b/src/niquests/structures.py
@@ -17,7 +17,9 @@ try:
     if not HAS_LEGACY_URLLIB3:
         from urllib3._collections import _lower_wrapper  # type: ignore[attr-defined]
     else:  # Defensive: tested in separate/isolated CI
-        from urllib3_future._collections import _lower_wrapper  # type: ignore[attr-defined]
+        from urllib3_future._collections import (
+            _lower_wrapper,  # type: ignore[attr-defined]
+        )
 except ImportError:
     from functools import lru_cache
 
@@ -30,9 +32,7 @@ except ImportError:
 from .exceptions import InvalidHeader
 
 
-def _ensure_str_or_bytes(
-    key: typing.Any, value: typing.Any
-) -> tuple[bytes | str, bytes | str]:
+def _ensure_str_or_bytes(key: typing.Any, value: typing.Any) -> tuple[bytes | str, bytes | str]:
     if isinstance(key, (bytes, str)) and isinstance(value, (bytes, str)):
         return key, value
     if isinstance(
@@ -43,9 +43,7 @@ def _ensure_str_or_bytes(
         ),
     ):
         value = str(value)
-    if isinstance(key, (bytes, str)) is False or (
-        value is not None and isinstance(value, (bytes, str)) is False
-    ):
+    if isinstance(key, (bytes, str)) is False or (value is not None and isinstance(value, (bytes, str)) is False):
         raise InvalidHeader(f"Illegal header name or value {key}")
     return key, value
 
@@ -137,9 +135,7 @@ class CaseInsensitiveDict(MutableMapping):
                 except TypeError:
                     yield (
                         t[0],
-                        ", ".join(
-                            v.decode() if isinstance(v, bytes) else v for v in t[1:]
-                        ),
+                        ", ".join(v.decode() if isinstance(v, bytes) else v for v in t[1:]),
                     )
 
     def __eq__(self, other) -> bool:
@@ -222,18 +218,14 @@ class QuicSharedCache(SharableLimitedDict):
         super().__init__(max_size)
         self._exclusion_store: typing.MutableMapping[typing.Any, typing.Any] = {}
 
-    def add_domain(
-        self, host: str, port: int | None = None, alt_port: int | None = None
-    ) -> None:
+    def add_domain(self, host: str, port: int | None = None, alt_port: int | None = None) -> None:
         if port is None:
             port = 443
         if alt_port is None:
             alt_port = port
         self[(host, port)] = (host, alt_port)
 
-    def exclude_domain(
-        self, host: str, port: int | None = None, alt_port: int | None = None
-    ):
+    def exclude_domain(self, host: str, port: int | None = None, alt_port: int | None = None):
         if port is None:
             port = 443
         if alt_port is None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from niquests import AsyncSession, AsyncResponse, Response
+from niquests import AsyncResponse, AsyncSession, Response
 from niquests.exceptions import MultiplexingError
 
 
@@ -272,9 +272,7 @@ class TestAsyncWithMultiplex:
 
             async with AsyncSession(multiplexed=True) as s:
                 responses.append(await s.get("https://httpbingo.org/get", stream=True))
-                responses.append(
-                    await s.get("https://httpbingo.org/delay/5", stream=True)
-                )
+                responses.append(await s.get("https://httpbingo.org/delay/5", stream=True))
 
                 await s.gather()
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -32,12 +32,7 @@ def test_hooks(hooks_list, result):
     ),
 )
 def test_hooks_with_kwargs(hooks_list, result):
-    assert (
-        hooks.dispatch_hook(
-            "response", {"response": hooks_list}, "Data", should_not_crash=True
-        )
-        == result
-    )
+    assert hooks.dispatch_hook("response", {"response": hooks_list}, "Data", should_not_crash=True) == result
 
 
 @pytest.mark.asyncio
@@ -49,9 +44,7 @@ def test_hooks_with_kwargs(hooks_list, result):
     ),
 )
 async def test_ahooks(hooks_list, result):
-    assert (
-        await hooks.async_dispatch_hook("response", {"response": hooks_list}, "Data")
-    ) == result
+    assert (await hooks.async_dispatch_hook("response", {"response": hooks_list}, "Data")) == result
 
 
 @pytest.mark.asyncio
@@ -63,11 +56,7 @@ async def test_ahooks(hooks_list, result):
     ),
 )
 async def test_ahooks_with_kwargs(hooks_list, result):
-    assert (
-        await hooks.async_dispatch_hook(
-            "response", {"response": hooks_list}, "Data", should_not_crash=True
-        )
-    ) == result
+    assert (await hooks.async_dispatch_hook("response", {"response": hooks_list}, "Data", should_not_crash=True)) == result
 
 
 def test_default_hooks():

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from niquests import Session
-from niquests.utils import is_ipv4_address, is_ipv6_address
-from niquests.exceptions import ConnectionError
 from niquests._compat import HAS_LEGACY_URLLIB3
+from niquests.exceptions import ConnectionError
+from niquests.utils import is_ipv4_address, is_ipv6_address
 
 if not HAS_LEGACY_URLLIB3:
     from urllib3 import HttpVersion, ResolverDescription

--- a/tests/test_ocsp.py
+++ b/tests/test_ocsp.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import pytest
 
-from niquests import Session, AsyncSession
+from niquests import AsyncSession, Session
 from niquests.exceptions import ConnectionError, Timeout
 
 try:
@@ -40,9 +42,7 @@ class TestOnlineCertificateRevocationProtocol:
                 try:
                     s.get(revoked_peer_url, timeout=OCSP_MAX_DELAY_WAIT)
                 except Timeout:
-                    pytest.mark.skip(
-                        f"remote {revoked_peer_url} is unavailable at the moment..."
-                    )
+                    pytest.mark.skip(f"remote {revoked_peer_url} is unavailable at the moment...")
             assert s._ocsp_cache is not None
             assert hasattr(s._ocsp_cache, "_store")
             assert isinstance(s._ocsp_cache._store, dict)
@@ -81,9 +81,7 @@ class TestOnlineCertificateRevocationProtocol:
                 try:
                     await s.get(revoked_peer_url, timeout=OCSP_MAX_DELAY_WAIT)
                 except Timeout:
-                    pytest.mark.skip(
-                        f"remote {revoked_peer_url} is unavailable at the moment..."
-                    )
+                    pytest.mark.skip(f"remote {revoked_peer_url} is unavailable at the moment...")
             assert s._ocsp_cache is not None
             assert hasattr(s._ocsp_cache, "_store")
             assert isinstance(s._ocsp_cache._store, dict)

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from niquests import Session, AsyncSession
+from niquests import AsyncSession, Session
 
 
 @pytest.mark.usefixtures("requires_wan")

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from niquests.structures import CaseInsensitiveDict, LookupDict
 from niquests._compat import HAS_LEGACY_URLLIB3
+from niquests.structures import CaseInsensitiveDict, LookupDict
 
 if not HAS_LEGACY_URLLIB3:
     from urllib3 import HTTPHeaderDict
@@ -21,9 +21,7 @@ class TestCaseInsensitiveDict:
     def test_list(self):
         assert list(self.case_insensitive_dict) == ["Accept"]
 
-    possible_keys = pytest.mark.parametrize(
-        "key", ("accept", "ACCEPT", "aCcEpT", "Accept")
-    )
+    possible_keys = pytest.mark.parametrize("key", ("accept", "ACCEPT", "aCcEpT", "Accept"))
 
     @possible_keys
     def test_getitem(self, key):
@@ -35,9 +33,7 @@ class TestCaseInsensitiveDict:
         assert key not in self.case_insensitive_dict
 
     def test_lower_items(self):
-        assert list(self.case_insensitive_dict.lower_items()) == [
-            ("accept", "application/json")
-        ]
+        assert list(self.case_insensitive_dict.lower_items()) == [("accept", "application/json")]
 
     def test_repr(self):
         assert repr(self.case_insensitive_dict) == "{'Accept': 'application/json'}"

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -43,9 +43,7 @@ class TestTestServer:
 
     def test_text_response(self):
         """the text_response_server sends the given text"""
-        server = Server.text_response_server(
-            "HTTP/1.1 200 OK\r\n" "Content-Length: 6\r\n" "\r\nroflol"
-        )
+        server = Server.text_response_server("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nroflol")
 
         with server as (host, port):
             r = niquests.get(f"http://{host}:{port}")
@@ -55,11 +53,7 @@ class TestTestServer:
             assert r.headers["Content-Length"] == "6"
 
     def test_early_response_caught(self):
-        server = Server.text_response_server(
-            "HTTP/1.1 100 CONTINUE\r\n\r\nHTTP/1.1 200 OK\r\n"
-            "Content-Length: 6\r\n"
-            "\r\nroflol"
-        )
+        server = Server.text_response_server("HTTP/1.1 100 CONTINUE\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nroflol")
 
         with server as (host, port):
             early_r = None
@@ -101,18 +95,14 @@ class TestTestServer:
 
     def test_invalid_location_response(self):
         server = Server.text_response_server(
-            "HTTP/1.1 302 PERMANENT-REDIRECTION\r\n"
-            "Location: http://localhost:1/search/?q=ïðåçèäåíòû+ÑØÀ\r\n\r\n"
+            "HTTP/1.1 302 PERMANENT-REDIRECTION\r\nLocation: http://localhost:1/search/?q=ïðåçèäåíòû+ÑØÀ\r\n\r\n"
         )
 
         with server as (host, port):
             with pytest.raises(niquests.exceptions.ConnectionError) as exc:
                 niquests.get(f"http://{host}:{port}")
             msg = exc.value.args[0].args[0]
-            assert (
-                "/search/?q=%C3%AF%C3%B0%C3%A5%C3%A7%C3%A8%C3%A4%C3%A5%C3%AD%C3%B2%C3%BB+%C3%91%C3%98%C3%80"
-                in msg
-            )
+            assert "/search/?q=%C3%AF%C3%B0%C3%A5%C3%A7%C3%A8%C3%A4%C3%A5%C3%AD%C3%B2%C3%BB+%C3%91%C3%98%C3%80" in msg
 
     def test_basic_response(self):
         """the basic response server returns an empty http response"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,8 +12,8 @@ from unittest import mock
 import pytest
 
 from niquests.cookies import RequestsCookieJar
-from niquests.structures import CaseInsensitiveDict
 from niquests.exceptions import MissingSchema
+from niquests.structures import CaseInsensitiveDict
 from niquests.utils import (
     _get_mask_bits,
     _parse_content_type_header,
@@ -32,6 +32,7 @@ from niquests.utils import (
     iter_slices,
     parse_dict_header,
     parse_header_links,
+    parse_scheme,
     prepend_scheme_if_needed,
     requote_uri,
     select_proxy,
@@ -42,7 +43,6 @@ from niquests.utils import (
     unquote_header_value,
     unquote_unreserved,
     urldefragauth,
-    parse_scheme,
 )
 
 
@@ -190,9 +190,7 @@ class TestGetEnvironProxies:
 
     @pytest.fixture(autouse=True, params=["no_proxy", "NO_PROXY"])
     def no_proxy(self, request, monkeypatch):
-        monkeypatch.setenv(
-            request.param, "192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1"
-        )
+        monkeypatch.setenv(request.param, "192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1")
         getproxies.cache_clear()
         getproxies_environment.cache_clear()
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from niquests import Session, AsyncSession, ReadTimeout
+from niquests import AsyncSession, ReadTimeout, Session
 
 try:
     import wsproto

--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -61,9 +61,7 @@ class Server(threading.Thread):
 
     @classmethod
     def basic_response_server(cls, **kwargs):
-        return cls.text_response_server(
-            "HTTP/1.1 200 OK\r\n" + "Content-Length: 0\r\n\r\n", **kwargs
-        )
+        return cls.text_response_server("HTTP/1.1 200 OK\r\n" + "Content-Length: 0\r\n\r\n", **kwargs)
 
     def run(self):
         try:
@@ -105,9 +103,7 @@ class Server(threading.Thread):
 
     def _accept_connection(self):
         try:
-            ready, _, _ = select.select(
-                [self.server_sock], [], [], self.WAIT_EVENT_TIMEOUT
-            )
+            ready, _, _ = select.select([self.server_sock], [], [], self.WAIT_EVENT_TIMEOUT)
             if not ready:
                 return None
 


### PR DESCRIPTION
3.12.2 (2025-01-22)
-------------------

**Fixed**
- Parsing of special scheme that exceed 9 characters on rare custom adapters.

**Changed**
- Default `Content-Type` for json payloads changed from `application/json; charset="utf-8"` to `application/json;charset=utf-8`.
  While the previous default was valid, this is the preferred value according to RFC9110. (#204)

**Misc**
- Removed a useless hasattr control to support older version of urllib3-future (<2.5).
- Updated our pre-commit configuration and reformatted files accordingly.
