### PR TITLE
add `__repr__` method to AsyncHTTPAdapter, HTTPAdapter

### DIFF
--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -441,6 +441,9 @@ class HTTPAdapter(BaseAdapter):
             keepalive_idle_window=keepalive_idle_window,
         )
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} pool_maxsize={self._pool_maxsize} max_retries={self.max_retries}>"
+
     def __getstate__(self) -> dict[str, typing.Any | None]:
         return {attr: getattr(self, attr, None) for attr in self.__attrs__}
 
@@ -1492,6 +1495,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
             keepalive_delay=keepalive_delay,
             keepalive_idle_window=keepalive_idle_window,
         )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} pool_maxsize={self._pool_maxsize} max_retries={self.max_retries}>"
 
     def __getstate__(self) -> dict[str, typing.Any | None]:
         return {attr: getattr(self, attr, None) for attr in self.__attrs__}


### PR DESCRIPTION
Hello,

This PR compliments my other PR over at https://github.com/jawah/urllib3.future/pull/205

Here I have covered both sync and async counterparts for HTTPAdapter & AsyncHTTPAdapter with a basic `repr` implementation. Please guide me on what more we can add to this and I'm happy to make the suggested changes.

G'day!