### PR TITLE
Release 3.13.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
+  rev: v1.15.0
   hooks:
   -   id: mypy
       args: [--check-untyped-defs]
       exclude: 'tests/|noxfile.py'
-      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.12.900', 'wassima>=1.0.1', 'qh3>=1.4']
+      additional_dependencies: ['charset_normalizer', 'urllib3.future>=2.12.900', 'wassima>=1.0.1', 'qh3>=1.4', '.']

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,17 @@
 Release History
 ===============
 
+3.13.1 (2025-03-09)
+-------------------
+
+**Added**
+- Internal shortcut to urllib3-future as `niquests.packages.urllib3`. This immediately helps end-user migrating
+  from Requests to Niquests and avoid the confusion around `urllib3` and `urllib3-future`.
+  The package own code benefit from it. `idna`, `charset_normalizer` (+ aliased as `chardet`) can be used also.
+
+**Misc**
+- The documentation is improved. Especially around sync/async examples and migration snippets.
+
 3.13.0 (2025-02-06)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Take a deeper look at https://github.com/Ousret/niquests-stats
 >>> r.status_code
 200
 >>> r.headers['content-type']
-'application/json; charset=utf8'
+'application/json; charset=utf-8'
 >>> r.oheaders.content_type.charset
-'utf8'
+'utf-8'
 >>> r.encoding
 'utf-8'
 >>> r.text

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,6 +64,12 @@ Lower-Level Classes
 
 .. warning:: AsyncResponse are only to be expected in async mode when you specify ``stream=True``. Otherwise expect the typical Response instance.
 
+.. autoclass:: RetryConfiguration
+   :inherited-members:
+
+.. autoclass:: TimeoutConfiguration
+   :inherited-members:
+
 Lower-Lower-Level Classes
 -------------------------
 
@@ -131,16 +137,10 @@ Removed
 * Property ``apparent_encoding`` in favor of a discrete internal inference.
 * Support for the legacy ``chardet`` detector in case it was present in environment.
   Extra ``chardet_on_py3`` is now unavailable.
-* Deprecated ``requests.packages`` that was meant to avoid breakage from people importing ``urllib3`` or ``chardet`` within this package.
-  They were _vendored_ in early versions of Requests. A long time ago.
 * Deprecated function ``get_encodings_from_content`` from utils.
 * Deprecated function ``get_unicode_from_response`` from utils.
 * BasicAuth middleware no-longer support anything else than ``bytes`` or ``str`` for username and password.
-* ``requests.compat`` is stripped of every reference that no longer vary between supported interpreter version.
 * Charset fall back **ISO-8859-1** when content-type is text and no charset was specified.
-* Main function ``get``, ``post``, ``put``, ``patch``, ``delete``, and ``head`` no longer accept **kwargs**. They have a fixed list of typed argument.
-  It is no longer possible to specify non-supported additional keyword argument from a ``Session`` instance or directly through ``requests.api`` functions.
-  e.g. function ``delete`` no-longer accept ``json``, or ``files`` arguments. as per RFCs specifications. You can still override this behavior through the ``request`` function.
 * Mixin classes ``RequestEncodingMixin``, and ``RequestHooksMixin`` due to OOP violations. Now deported directly into child classes.
 * Function ``unicode_is_ascii`` as it is part of the stable ``str`` stdlib on Python 3 or greater.
 * Alias function ``session`` for ``Session`` context manager that was kept for BC reasons since the v1.

--- a/docs/community/extensions.rst
+++ b/docs/community/extensions.rst
@@ -57,7 +57,7 @@ Apply the following code to your ``conftest.py``::
 
     import requests
     import niquests
-    import urllib3
+    from niquests.packages import urllib3
 
     # responses is tied to Requests
     # and Niquests is entirely compatible with it.
@@ -79,7 +79,7 @@ Apply the following code to your ``conftest.py``::
 
     import requests
     import niquests
-    import urllib3
+    import niquests.packages import urllib3
 
     # betamax is tied to Requests
     # and Niquests is almost entirely compatible with it.
@@ -145,7 +145,7 @@ You will need to create a fixture to override the default bind to Requests in ``
 
     import requests
     import niquests
-    import urllib3
+    from niquests.packages import urllib3
 
     # impersonate Requests!
     modules["requests"] = niquests

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -62,7 +62,7 @@ Do as follow::
         ...
 
 
-.. note:: Previously Requests and urllib3 was non-strict and allowed infinite growth of the pool by default. This was undesirable.
+.. note:: Previously Requests and urllib3 was non-strict and allowed infinite growth of the pool by default. This is undesirable.
     Upon exceeding the maximum pool capacity, urllib3 starts to create "disposable" connections that are killed as soon as possible.
     This behavior masked an issue and users were misinformed about it.
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -91,6 +91,12 @@ out-of-the-box with urllib3.future.
 This behavior was chosen to ensure the highest level of compatibility for your migration,
 ensuring the minimum friction during the migration between Requests to Niquests.
 
+Instead of importing ``urllib3`` do::
+
+    from niquests.packages import urllib3
+
+The package internally make sure you get it right everytime!
+
 Cohabitation
 ~~~~~~~~~~~~
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,6 @@ sys.path.insert(0, os.path.abspath("../src"))
 
 import niquests
 
-sys.modules["requests"] = niquests
-
 
 # -- General configuration ------------------------------------------------
 
@@ -43,6 +41,7 @@ extensions = [
     "sphinxcontrib.googleanalytics",
     "sphinx_copybutton",
     "sphinx_mdinclude",
+    "sphinx_inline_tabs",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -136,7 +135,19 @@ html_theme_options = {
         "color-brand-primary": "#7C4DFF",
         "color-brand-content": "#7C4DFF",
     },
+    "announcement": """
+        <a style=\"text-decoration: none; color: white;\" 
+           href=\"https://github.com/jawah/Niquests\">
+            ⭐ Mark your support for Niquests initiative to bring an excellent, fair and free HTTP experience!
+        </a>
+        <iframe src="https://ghbtns.com/github-btn.html?user=jawah&repo=niquests&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+        """,
+    "sidebar_hide_name": True,
 }
+
+html_js_files = [
+    'https://unpkg.com/@terminhtml/bootstrap@1.x/dist/@terminhtml-bootstrap.umd.js'
+]
 
 googleanalytics_id = "G-F8C2DJ1CJN"
 
@@ -145,10 +156,10 @@ googleanalytics_id = "G-F8C2DJ1CJN"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-# html_title = None
+html_title = "Niquests Documentation – Drop-in replacement for Requests – HTTP/1.1, HTTP/2, and HTTP/3."
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = None
+html_short_title = f"Niquests {version} Documentation"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -254,7 +265,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "Niquests.tex", u"Niquests Documentation", u"Kenneth Reitz", "manual")
+    (master_doc, "Niquests.tex", "Niquests Documentation – Drop-in replacement for Requests. HTTP/1.1, HTTP/2, and HTTP/3.", u"Kenneth Reitz", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -282,7 +293,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "niquests", u"Niquests Documentation", [author], 1)]
+man_pages = [(master_doc, "niquests", "Niquests Documentation – Drop-in replacement for Requests. HTTP/1.1, HTTP/2, and HTTP/3.", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -297,7 +308,7 @@ texinfo_documents = [
     (
         master_doc,
         "Niquests",
-        u"Niquests Documentation",
+        "Niquests Documentation – Drop-in replacement for Requests. HTTP/1.1, HTTP/2, and HTTP/3.",
         author,
         "Niquests",
         "“Safest, Fastest, Easiest, and Most advanced” Python HTTP Client. Production Ready! Drop-in replacement for Requests. HTTP/1.1, HTTP/2, and HTTP/3 supported. With WebSocket, and SSE! Be free of Requests bondage now.",

--- a/docs/dev/migrate.rst
+++ b/docs/dev/migrate.rst
@@ -38,6 +38,22 @@ Or simply
 
 .. tip:: If you were used to use ``urllib3.Timeout`` or ``urllib3.Retry`` you can either keep them as-is or use our fully compatible ``niquests.RetryConfiguration`` or ``niquests.TimeoutConfiguration`` instead.
 
+If you were used to depends on urllib3.
+
+.. code:: python
+
+    from urllib3 import Timeout
+    import requests
+
+Will now become:
+
+.. code:: python
+
+    import niquests
+    from niquests.packages.urllib3 import Timeout
+
+.. note:: urllib3 is safely aliased as ``niquests.packages.urllib3``. Using the alias provided by Niquests is safer.
+
 Maintainer migration
 --------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,17 +28,20 @@ Supports HTTP/1.1, HTTP/2 and HTTP/3 out-of-the-box without breaking a sweat!
 
 -------------------
 
-**Behold, the power of Niquests**::
+**Behold, the power of Niquests**
 
+.. raw:: html
+
+   <pre class="terminhtml">
    >>> import niquests
-   >>> s = niquests.Session(resolver="doh+google://", multiplexed=True)
+   >>> s = niquests.Session(resolver="doh+google://")
    >>> r = s.get('https://pie.dev/basic-auth/user/pass', auth=('user', 'pass'))
    >>> r.status_code
    200
    >>> r.headers['content-type']
-   'application/json; charset=utf8'
+   'application/json; charset=utf-8'
    >>> r.oheaders.content_type.charset
-   'utf8'
+   'utf-8'
    >>> r.encoding
    'utf-8'
    >>> r.text
@@ -46,14 +49,12 @@ Supports HTTP/1.1, HTTP/2 and HTTP/3 out-of-the-box without breaking a sweat!
    >>> r.json()
    {'authenticated': True, ...}
    >>> r
-   <Response HTTP/3 [200]>
+   &lt;Response HTTP/3 [200]&gt;
    >>> r.ocsp_verified
    True
    >>> r.conn_info.established_latency
    datetime.timedelta(microseconds=38)
-
-See `similar code, sans Niquests <https://gist.github.com/973705>`_.
-
+   </pre>
 
 **Niquests** allows you to send HTTP/1.1, HTTP/2 and HTTP/3 requests extremely easily.
 There's no need to manually add query strings to your

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ kiss_headers>=2,<4
 furo>=2023.9.10
 sphinx-mdinclude==0.6.2
 sphinxcontrib-googleanalytics==0.4
+sphinx-inline-tabs==2023.4.21

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -305,7 +305,7 @@ DNS with mTLS
 You can pass your client side certificate to authenticate yourself against the given resolver.
 To do so, you will have to do as follow::
 
-    from urllib3 import ResolverDescription
+    from niquests.packages.urllib3 import ResolverDescription
     from niquests import Session
 
     rd = ResolverDescription.from_url("doq://my-resolver.tld")
@@ -1180,7 +1180,7 @@ passed-through to `urllib3.future`. We'll make a Transport Adapter that instruct
 library to use SSLv3::
 
     import ssl
-    from urllib3.poolmanager import PoolManager
+    from niquests.packages.urllib3 import PoolManager
 
     from niquests.adapters import HTTPAdapter
 
@@ -1201,7 +1201,7 @@ to implement automatic retries with a powerful array of features, including
 backoff, within a Niquests :class:`Session <niquests.Session>` using the
 `urllib3.util.Retry`_ class::
 
-    from urllib3.util import Retry
+    from niquests.packages.urllib3.util import Retry
     from niquests import Session
 
     retries = Retry(

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -7,12 +7,103 @@ This part of the documentation covers the installation of Niquests.
 The first step to using any software package is getting it properly installed.
 
 
-$ python -m pip install niquests
---------------------------------
+$ Install!
+----------
 
 To install Niquests, simply run this simple command in your terminal of choice::
 
     $ python -m pip install niquests
+
+
+Dependencies
+~~~~~~~~~~~~
+
+Niquests has currently 3 mandatory dependencies.
+
+- **wassima**
+  - This package allows Niquests a seamless access to your native OS trust store. It avoids to rely on ``certify``.
+- **urllib3-future**
+  - The direct and immediate replacement for the well known ``urllib3`` package. Serve as the Niquests core.
+- **charset-normalizer**
+  - A clever encoding detector that helps provide a smooth user experience when dealing with legacy resources.
+
+*urllib3-future* itself depends on three other dependencies. Two of them are installed everytime (mandatory).
+
+- **h11**
+  - A state-machine to speak HTTP/1.1
+- **jh2**
+  - A state-machine to speak HTTP/2
+- **qh3**
+  - A QUIC stack with a HTTP/3 state-machine
+
+.. note::
+    **qh3** may not be installed on your machine even if **urllib3-future** depends on it.
+    That dependency is BOTH required AND optional.
+    There's a lot of markers in the requirement definition to prevent someone to accidentally try compile the source.
+    **qh3** is not pure Python and ship a ton of prebuilt wheels, but unfortunately it is
+    impossible to ship every possible combination of system/architecture.
+    e.g. this is why doing ``pip install niquests`` on a riscv linux distro will NOT bring **qh3**. but will for arm64, i686 or x86_64.
+
+.. warning::
+    Depending on your environment and installation order you could be surprised that ``urllib3-future`` replaces
+    ``urllib3`` in your environment. Fear not, as this package was perfectly designed to allows the best
+    backward-compatibility possible for end-users.
+    Installing Niquests affect other packages, as they will use ``urllib3-future`` instead of ``urllib3``.
+    The prevalent changes are as follow: No longer using HTTP/1 by default, not depending on ``http.client``, can
+    negotiate HTTP/2, and HTTP/3, backward compatible with old Python and OpenSSL, not opinionated on other SSL backend,
+    and finally faster. This list isn't exhaustive. Any issues encountered regarding this cohabitation will be handled
+    at https://github.com/jawah/urllib3.future with the utmost priority. Find deeper rational in the exposed repository.
+
+.. note::
+    Doing a ``pip install --force-reinstall urllib3`` will restore the legacy urllib3 in a flash if needed.
+    At the cost of loosing the perfect backward compatibility with third party plugins (using Niquests).
+
+Extras
+~~~~~~
+
+Niquests come with a few extras that requires you to install the package with a specifier.
+
+- **ws**
+
+To benefit from the integrated WebSocket experience, you may install Niquests as follow::
+
+    $ python -m pip install niquests[ws]
+
+- **socks**
+
+SOCKS proxies can be used in Niquests, at the sole condition to have::
+
+    $ python -m pip install niquests[socks]
+
+- **Brotli**, **Zstandard** (zstd) and **orjson**
+
+Niquests can run significantly faster when your environment is capable of decompressing Brotli, and Zstd.
+Also, we took the liberty to allows using the alternative json decoder ``orjson`` that is faster than the
+standard json library.
+
+To immediately benefit from this, run::
+
+    $ python -m pip install niquests[speedups]
+
+.. note:: You may at your own discretion choose multiple options such as ``pip install niquests[socks,ws]``.
+
+.. note:: You can install every optionals by running ``pip install niquests[full]``.
+
+If you don't want ``orjson`` to be present and only zstd for example, run::
+
+    $ python -m pip install niquests[zstd]
+
+- **http3** or/and **ocsp**
+
+As explained higher in this section, our HTTP/3 implementation depends on you having ``qh3`` installed. And it may not
+be the case depending on your environment.
+
+To force install ``qh3`` run the installation using::
+
+    $ python -m pip install niquests[http3]
+
+
+.. note:: ``ocsp`` extra is a mere alias of ``http3``. Our OCSP client depends on **qh3** inners anyway.
 
 Get the Source Code
 -------------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -16,40 +16,92 @@ First, make sure that:
 
 Let's get started with some simple examples.
 
+.. note::
+
+    Any async example must be enclosed in a proper async function and started by ``asyncio.run(...)``.
+
+    .. code:: python
+
+        import asyncio
+        import niquests
+
+        async def main() -> None:
+            """past your example code here!"""
+
+        if __name__ == "__main__":
+            asyncio.run(main())
+
 
 Make a Request
 --------------
 
 Making a request with Niquests is very simple.
 
-Begin by importing the Niquests module::
+Begin by importing the Niquests module:
 
-    >>> import niquests
+.. code:: python
+
+    import niquests
 
 Now, let's try to get a webpage. For this example, let's get GitHub's public
-timeline::
+timeline.
 
-    >>> r = niquests.get('https://api.github.com/events')
+.. tab:: 🔂 Sync
+
+    .. code:: python
+
+        r = niquests.get('https://api.github.com/events')
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            r = await s.get('https://api.github.com/events')
 
 Now, we have a :class:`Response <niquests.Response>` object called ``r``. We can
 get all the information we need from this object.
 
 Niquests' simple API means that all forms of HTTP request are as obvious. For
-example, this is how you make an HTTP POST request::
+example, this is how you make an HTTP POST request:
 
-    >>> r = niquests.post('https://httpbin.org/post', data={'key': 'value'})
+.. tab:: 🔂 Sync
+
+    .. code:: python
+
+        r = niquests.post('https://httpbin.org/post', data={'key': 'value'})
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            r = await s.post('https://httpbin.org/post', data={'key': 'value'})
 
 Nice, right? What about the other HTTP request types: PUT, DELETE, HEAD and
-OPTIONS? These are all just as simple::
+OPTIONS? These are all just as simple:
 
-    >>> r = niquests.put('https://httpbin.org/put', data={'key': 'value'})
-    >>> r = niquests.delete('https://httpbin.org/delete')
-    >>> r = niquests.head('https://httpbin.org/get')
-    >>> r = niquests.options('https://httpbin.org/get')
+.. tab:: 🔂 Sync
+
+    .. code:: python
+
+        r = niquests.put('https://httpbin.org/put', data={'key': 'value'})
+        r = niquests.delete('https://httpbin.org/delete')
+        r = niquests.head('https://httpbin.org/get')
+        r = niquests.options('https://httpbin.org/get')
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            r = await s.put('https://httpbin.org/put', data={'key': 'value'})
+            r = await s.delete('https://httpbin.org/delete')
+            r = await s.head('https://httpbin.org/get')
+            r = await s.options('https://httpbin.org/get')
 
 That's all well and good, but it's also only the start of what Niquests can
 do.
-
 
 Passing Parameters In URLs
 --------------------------
@@ -60,38 +112,77 @@ pairs in the URL after a question mark, e.g. ``httpbin.org/get?key=val``.
 Niquests allows you to provide these arguments as a dictionary of strings,
 using the ``params`` keyword argument. As an example, if you wanted to pass
 ``key1=value1`` and ``key2=value2`` to ``httpbin.org/get``, you would use the
-following code::
+following code:
 
-    >>> payload = {'key1': 'value1', 'key2': 'value2'}
-    >>> r = niquests.get('https://httpbin.org/get', params=payload)
+.. tab:: 🔂 Sync
 
-You can see that the URL has been correctly encoded by printing the URL::
+    .. code:: python
 
-    >>> print(r.url)
-    https://httpbin.org/get?key2=value2&key1=value1
+        payload = {'key1': 'value1', 'key2': 'value2'}
+        r = niquests.get('https://httpbin.org/get', params=payload)
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            payload = {'key1': 'value1', 'key2': 'value2'}
+            r = await s.get('https://httpbin.org/get', params=payload)
+
+You can see that the URL has been correctly encoded by printing the URL:
+
+.. code:: python
+
+    print(r.url)  # 'https://httpbin.org/get?key2=value2&key1=value1'
 
 Note that any dictionary key whose value is ``None`` will not be added to the
 URL's query string.
 
-You can also pass a list of items as a value::
+You can also pass a list of items as a value:
 
-    >>> payload = {'key1': 'value1', 'key2': ['value2', 'value3']}
+.. tab:: 🔂 Sync
 
-    >>> r = niquests.get('https://httpbin.org/get', params=payload)
-    >>> print(r.url)
-    https://httpbin.org/get?key1=value1&key2=value2&key2=value3
+    .. code:: python
+
+        payload = {'key1': 'value1', 'key2': ['value2', 'value3']}
+        r = niquests.get('https://httpbin.org/get', params=payload)
+
+        print(r.url)  # 'https://httpbin.org/get?key1=value1&key2=value2&key2=value3'
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            payload = {'key1': 'value1', 'key2': ['value2', 'value3']}
+            r = await s.get('https://httpbin.org/get', params=payload)
+
+            print(r.url)  # 'https://httpbin.org/get?key1=value1&key2=value2&key2=value3'
 
 Response Content
 ----------------
 
 We can read the content of the server's response. Consider the GitHub timeline
-again::
+again:
 
-    >>> import niquests
+.. tab:: 🔂 Sync
 
-    >>> r = niquests.get('https://api.github.com/events')
-    >>> r.text
-    '[{"repository":{"open_issues":0,"url":"https://github.com/...
+    .. code:: python
+
+        import niquests
+
+        r = niquests.get('https://api.github.com/events')
+        print(r.text)  # '[{"repository":{"open_issues":0,"url":"https://github.com/...
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        import niquests
+
+        async with niquests.AsyncSession() as s:
+            r = await s.get('https://api.github.com/events')
+            print(r.text)  # '[{"repository":{"open_issues":0,"url":"https://github.com/...
 
 Niquests will automatically decode content from the server. Most unicode
 charsets are seamlessly decoded.
@@ -99,11 +190,13 @@ charsets are seamlessly decoded.
 When you make a request, Niquests makes educated guesses about the encoding of
 the response based on the HTTP headers. The text encoding guessed by Niquests
 is used when you access ``r.text``. You can find out what encoding Niquests is
-using, and change it, using the ``r.encoding`` property::
+using, and change it, using the ``r.encoding`` property:
 
-    >>> r.encoding
-    'utf-8'
-    >>> r.encoding = 'ISO-8859-1'
+.. code:: python
+
+    print(r.encoding)  # 'utf-8'
+
+    r.encoding = 'ISO-8859-1'  # force assign a specific encoding!
 
 .. warning:: If Niquests is unable to decode the content to string with confidence, it simply return None.
 
@@ -147,13 +240,26 @@ use the following code::
 JSON Response Content
 ---------------------
 
-There's also a builtin JSON decoder, in case you're dealing with JSON data::
+There's also a builtin JSON decoder, in case you're dealing with JSON data:
 
-    >>> import niquests
+.. tab:: 🔂 Sync
 
-    >>> r = niquests.get('https://api.github.com/events')
-    >>> r.json()
-    [{'repository': {'open_issues': 0, 'url': 'https://github.com/...
+    .. code:: python
+
+        import niquests
+
+        r = niquests.get('https://api.github.com/events')
+        print(r.json())  # [{'repository': {'open_issues': 0, 'url': 'https://github.com/...
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        import niquests
+
+        async with niquests.AsyncSession() as s:
+            r = await s.get('https://api.github.com/events')
+            print(r.json())  # [{'repository': {'open_issues': 0, 'url': 'https://github.com/...
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,
@@ -178,22 +284,54 @@ Raw Response Content
 
 In the rare case that you'd like to get the raw socket response from the
 server, you can access ``r.raw``. If you want to do this, make sure you set
-``stream=True`` in your initial request. Once you do, you can do this::
+``stream=True`` in your initial request. Once you do, you can do this:
 
-    >>> r = niquests.get('https://api.github.com/events', stream=True)
+.. tab:: 🔂 Sync
 
-    >>> r.raw
-    <urllib3.response.HTTPResponse object at 0x101194810>
+    .. code:: python
 
-    >>> r.raw.read(10)
-    b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03'
+        r = niquests.get('https://api.github.com/events', stream=True)
+
+        r.raw
+        # <urllib3.response.HTTPResponse object at 0x101194810>
+
+        r.raw.read(10)
+        # b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03'
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            r = await s.get('https://api.github.com/events', stream=True)
+
+            r.raw
+            # <urllib3._async.response.AsyncHTTPResponse object at 0x101194810>
+
+            await r.raw.read(10)
+            # b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03'
+
 
 In general, however, you should use a pattern like this to save what is being
-streamed to a file::
+streamed to a file:
 
-    with open(filename, 'wb') as fd:
-        for chunk in r.iter_content(chunk_size=128):
-            fd.write(chunk)
+.. tab:: 🔂 Sync
+
+    .. code:: python
+
+        with open(filename, 'wb') as fd:
+            for chunk in r.iter_content(chunk_size=128):
+                fd.write(chunk)
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        with open(filename, 'wb') as fd:
+            async for chunk in await r.iter_content(chunk_size=128):
+                fd.write(chunk)
+
+    .. warning:: It is recommended to use ``aiofile`` or similar to handle file I/O in async mode.
 
 Using ``Response.iter_content`` will handle a lot of what you would otherwise
 have to handle when using ``Response.raw`` directly. When streaming a
@@ -216,12 +354,26 @@ Custom Headers
 If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
 ``headers`` parameter.
 
-For example, we didn't specify our user-agent in the previous example::
+For example, we didn't specify our user-agent in the previous example:
 
-    >>> url = 'https://api.github.com/some/endpoint'
-    >>> headers = {'user-agent': 'my-app/0.0.1'}
+.. tab:: 🔂 Sync
 
-    >>> r = niquests.get(url, headers=headers)
+    .. code:: python
+
+        url = 'https://api.github.com/some/endpoint'
+        headers = {'user-agent': 'my-app/0.0.1'}
+
+        r = niquests.get(url, headers=headers)
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession() as s:
+            url = 'https://api.github.com/some/endpoint'
+            headers = {'user-agent': 'my-app/0.0.1'}
+
+            r = await s.get(url, headers=headers)
 
 Note: Custom headers are given less precedence than more specific sources of information. For instance:
 
@@ -242,7 +394,9 @@ More complicated POST requests
 
 Typically, you want to send some form-encoded data — much like an HTML form.
 To do this, simply pass a dictionary to the ``data`` argument. Your
-dictionary of data will automatically be form-encoded when the request is made::
+dictionary of data will automatically be form-encoded when the request is made:
+
+.. code:: python
 
     >>> payload = {'key1': 'value1', 'key2': 'value2'}
 
@@ -647,7 +801,7 @@ alternative service. Once it finds it, and is deemed valid, it opens up a QUIC c
 It is saved in-memory by Niquests.
 
 You may also run the following command ``python -m niquests.help`` to find out if you support HTTP/3.
-In 95 percents of the case, the answer is yes!
+In 98 percents of the case, the answer is yes!
 
 .. note:: Since urllib3.future version 2.4+ we support negotiating HTTP/3 without a first TCP connection if the remote peer indicated in a HTTPS (DNS) record that the server support HTTP/3.
 
@@ -667,6 +821,9 @@ Any ``Response`` returned by get, post, put, etc... will be a lazy instance of `
    An important note about using ``Session(multiplexed=True)`` is that, in order to be efficient
    and actually leverage its perks, you will have to issue multiple concurrent request before
    actually trying to access any ``Response`` methods or attributes.
+
+Modern browsers like Firefox, and Chrome utilize something really like ``multiplexed=True`` mode!
+It's a bit like if we have a controlled concurrent environment.
 
 Gather responses
 ~~~~~~~~~~~~~~~~
@@ -1045,18 +1202,6 @@ You may set a specific timeout for domain name resolution by appending ``?timeou
         resp = s.get("https://httpbingo.org/get")
 
 This will prevent any resolution that last longer to a second.
-
-Speedups
---------
-
-Niquests support a wide range of optional dependencies that enable a significant speedup in your
-everyday HTTP flows.
-
-To enable various optimizations, such as native zstandard decompression and faster json serializer/deserializer,
-install Niquests with::
-
-    $ python -m pip install niquests[speedups]
-
 
 Happy Eyeballs
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ select = [
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
 
+[[tool.mypy.overrides]]
+module = ["niquests.packages.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,16 @@ speedups = [
     "orjson>=3,<4",
     "urllib3.future[zstd,brotli]",
 ]
+zstd = [
+    "urllib3.future[zstd]",
+]
+brotli = [
+    "urllib3.future[brotli]",
+]
+full = [
+    "orjson>=3,<4",
+    "urllib3.future[zstd,brotli,ws,socks]",
+]
 
 [project.urls]
 "Changelog" = "https://github.com/jawah/niquests/blob/main/HISTORY.md"

--- a/src/niquests/__init__.py
+++ b/src/niquests/__init__.py
@@ -46,19 +46,13 @@ import warnings
 from logging import NullHandler
 
 from ._compat import HAS_LEGACY_URLLIB3
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import Retry as RetryConfiguration
-    from urllib3 import Timeout as TimeoutConfiguration
-    from urllib3.exceptions import DependencyWarning
-else:
-    from urllib3_future import (  # type: ignore[assignment]
-        Retry as RetryConfiguration,
-    )
-    from urllib3_future import (  # type: ignore[assignment]
-        Timeout as TimeoutConfiguration,
-    )
-    from urllib3_future.exceptions import DependencyWarning  # type: ignore[assignment]
+from .packages.urllib3 import (
+    Retry as RetryConfiguration,
+)
+from .packages.urllib3 import (
+    Timeout as TimeoutConfiguration,
+)
+from .packages.urllib3.exceptions import DependencyWarning
 
 # urllib3's DependencyWarnings should be silenced.
 warnings.simplefilter("ignore", DependencyWarning)
@@ -138,4 +132,5 @@ __all__ = (
     "AsyncResponse",
     "TimeoutConfiguration",
     "RetryConfiguration",
+    "HAS_LEGACY_URLLIB3",
 )

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.13.0"
+__version__ = "3.13.1"
 
-__build__: int = 0x031300
+__build__: int = 0x031301
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/_async.py
+++ b/src/niquests/_async.py
@@ -16,20 +16,6 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal
 
 from ._compat import HAS_LEGACY_URLLIB3, urllib3_ensure_type
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ConnectionInfo
-    from urllib3.contrib.resolver._async import AsyncBaseResolver
-    from urllib3.contrib.webextensions._async import load_extension
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
-        AsyncBaseResolver,
-    )
-    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
-        load_extension,
-    )
-
 from ._constant import (
     DEFAULT_POOLSIZE,
     DEFAULT_RETRIES,
@@ -79,6 +65,9 @@ from .models import (
     Response,
     TransferProgress,
 )
+from .packages.urllib3 import ConnectionInfo
+from .packages.urllib3.contrib.resolver._async import AsyncBaseResolver
+from .packages.urllib3.contrib.webextensions._async import load_extension
 from .sessions import Session
 from .structures import AsyncQuicSharedCache
 from .utils import (

--- a/src/niquests/_typing.py
+++ b/src/niquests/_typing.py
@@ -4,28 +4,12 @@ import typing
 from http.cookiejar import CookieJar
 from os import PathLike
 
-from ._compat import HAS_LEGACY_URLLIB3
 from ._vendor.kiss_headers import Headers
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import AsyncResolverDescription, ResolverDescription, Retry, Timeout
-    from urllib3.contrib.resolver import BaseResolver
-    from urllib3.contrib.resolver._async import AsyncBaseResolver
-    from urllib3.fields import RequestField
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import (  # type: ignore[assignment]
-        AsyncResolverDescription,
-        ResolverDescription,
-        Retry,
-        Timeout,
-    )
-    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
-        AsyncBaseResolver,
-    )
-    from urllib3_future.fields import RequestField  # type: ignore[assignment]
-
 from .auth import AsyncAuthBase, AuthBase
+from .packages.urllib3 import AsyncResolverDescription, ResolverDescription, Retry, Timeout
+from .packages.urllib3.contrib.resolver import BaseResolver
+from .packages.urllib3.contrib.resolver._async import AsyncBaseResolver
+from .packages.urllib3.fields import RequestField
 from .structures import CaseInsensitiveDict
 
 if typing.TYPE_CHECKING:

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -26,127 +26,7 @@ if sys.platform == "win32":
 else:
     preferred_clock = time.time
 
-from ._compat import HAS_LEGACY_URLLIB3, urllib3_ensure_type
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import (
-        AsyncHTTPConnectionPool,
-        AsyncHTTPSConnectionPool,
-        AsyncPoolManager,
-        AsyncProxyManager,
-        AsyncResolverDescription,
-        BaseHTTPResponse,
-        ConnectionInfo,
-        HTTPConnectionPool,
-        HTTPSConnectionPool,
-        HttpVersion,
-        PoolManager,
-        ProxyManager,
-        ResolverDescription,
-        ResponsePromise,
-        async_proxy_from_url,
-        proxy_from_url,
-    )
-    from urllib3 import (
-        AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3.contrib.resolver import BaseResolver
-    from urllib3.contrib.resolver._async import AsyncBaseResolver
-    from urllib3.contrib.webextensions import load_extension
-    from urllib3.contrib.webextensions._async import (
-        load_extension as async_load_extension,
-    )
-    from urllib3.exceptions import (
-        ClosedPoolError,
-        ConnectTimeoutError,
-        LocationValueError,
-        MaxRetryError,
-        NewConnectionError,
-        ProtocolError,
-        ReadTimeoutError,
-        ResponseError,
-    )
-    from urllib3.exceptions import (
-        HTTPError as _HTTPError,
-    )
-    from urllib3.exceptions import (
-        InvalidHeader as _InvalidHeader,
-    )
-    from urllib3.exceptions import (
-        ProxyError as _ProxyError,
-    )
-    from urllib3.exceptions import (
-        SSLError as _SSLError,
-    )
-    from urllib3.util import (
-        Retry,
-        parse_url,
-    )
-    from urllib3.util import (
-        Timeout as TimeoutSauce,
-    )
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import (  # type: ignore[assignment]
-        AsyncHTTPConnectionPool,
-        AsyncHTTPSConnectionPool,
-        AsyncPoolManager,
-        AsyncProxyManager,
-        AsyncResolverDescription,
-        BaseHTTPResponse,
-        ConnectionInfo,
-        HTTPConnectionPool,
-        HTTPSConnectionPool,
-        HttpVersion,
-        PoolManager,
-        ProxyManager,
-        ResolverDescription,
-        ResponsePromise,
-        async_proxy_from_url,
-        proxy_from_url,
-    )
-    from urllib3_future import (  # type: ignore[assignment]
-        AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
-        AsyncBaseResolver,
-    )
-    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
-        load_extension,
-    )
-    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
-        load_extension as async_load_extension,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        ClosedPoolError,
-        ConnectTimeoutError,
-        LocationValueError,
-        MaxRetryError,
-        NewConnectionError,
-        ProtocolError,
-        ReadTimeoutError,
-        ResponseError,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        HTTPError as _HTTPError,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        InvalidHeader as _InvalidHeader,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        ProxyError as _ProxyError,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        SSLError as _SSLError,
-    )
-    from urllib3_future.util import (  # type: ignore[assignment]
-        Retry,
-        parse_url,
-    )
-    from urllib3_future.util import (  # type: ignore[assignment]
-        Timeout as TimeoutSauce,
-    )
-
+from ._compat import urllib3_ensure_type
 from ._constant import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES
 from ._typing import (
     AsyncResolverType,
@@ -177,6 +57,62 @@ from .exceptions import (
 )
 from .hooks import async_dispatch_hook, dispatch_hook
 from .models import AsyncResponse, PreparedRequest, Response
+from .packages.urllib3 import (
+    AsyncHTTPConnectionPool,
+    AsyncHTTPSConnectionPool,
+    AsyncPoolManager,
+    AsyncProxyManager,
+    AsyncResolverDescription,
+    BaseHTTPResponse,
+    ConnectionInfo,
+    HTTPConnectionPool,
+    HTTPSConnectionPool,
+    HttpVersion,
+    PoolManager,
+    ProxyManager,
+    ResolverDescription,
+    ResponsePromise,
+    async_proxy_from_url,
+    proxy_from_url,
+)
+from .packages.urllib3 import (
+    AsyncHTTPResponse as BaseAsyncHTTPResponse,
+)
+from .packages.urllib3.contrib.resolver import BaseResolver
+from .packages.urllib3.contrib.resolver._async import AsyncBaseResolver
+from .packages.urllib3.contrib.webextensions import load_extension
+from .packages.urllib3.contrib.webextensions._async import (
+    load_extension as async_load_extension,
+)
+from .packages.urllib3.exceptions import (
+    ClosedPoolError,
+    ConnectTimeoutError,
+    LocationValueError,
+    MaxRetryError,
+    NewConnectionError,
+    ProtocolError,
+    ReadTimeoutError,
+    ResponseError,
+)
+from .packages.urllib3.exceptions import (
+    HTTPError as _HTTPError,
+)
+from .packages.urllib3.exceptions import (
+    InvalidHeader as _InvalidHeader,
+)
+from .packages.urllib3.exceptions import (
+    ProxyError as _ProxyError,
+)
+from .packages.urllib3.exceptions import (
+    SSLError as _SSLError,
+)
+from .packages.urllib3.util import (
+    Retry,
+    parse_url,
+)
+from .packages.urllib3.util import (
+    Timeout as TimeoutSauce,
+)
 from .structures import CaseInsensitiveDict
 from .utils import (
     _deepcopy_ci,
@@ -194,13 +130,7 @@ from .utils import (
 )
 
 try:
-    if HAS_LEGACY_URLLIB3 is False:
-        from urllib3.contrib.socks import AsyncSOCKSProxyManager, SOCKSProxyManager
-    else:
-        from urllib3_future.contrib.socks import (  # type: ignore[assignment]
-            AsyncSOCKSProxyManager,
-            SOCKSProxyManager,
-        )
+    from .packages.urllib3.contrib.socks import AsyncSOCKSProxyManager, SOCKSProxyManager
 except ImportError:
 
     def SOCKSProxyManager(*args: typing.Any, **kwargs: typing.Any) -> None:  # type: ignore[no-redef]

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -20,13 +20,8 @@ from http.cookiejar import CookieJar
 from http.cookies import Morsel
 from urllib.parse import urlparse, urlunparse
 
-from ._compat import HAS_LEGACY_URLLIB3
+from .packages.urllib3 import BaseHTTPResponse
 from .utils import parse_scheme
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import BaseHTTPResponse
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import BaseHTTPResponse  # type: ignore[assignment]
 
 if typing.TYPE_CHECKING:
     from .models import PreparedRequest, Request

--- a/src/niquests/exceptions.py
+++ b/src/niquests/exceptions.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 import typing
 from json import JSONDecodeError as CompatJSONDecodeError
 
-from ._compat import HAS_LEGACY_URLLIB3
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3.exceptions import HTTPError as BaseHTTPError
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future.exceptions import HTTPError as BaseHTTPError  # type: ignore
+from .packages.urllib3.exceptions import HTTPError as BaseHTTPError
 
 if typing.TYPE_CHECKING:
     from .models import PreparedRequest, Response

--- a/src/niquests/extensions/_async_ocsp.py
+++ b/src/niquests/extensions/_async_ocsp.py
@@ -19,26 +19,14 @@ from qh3._hazmat import (
     OCSPResponseStatus,
 )
 
-from .._compat import HAS_LEGACY_URLLIB3
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ConnectionInfo
-    from urllib3.contrib.resolver._async import AsyncBaseResolver
-    from urllib3.contrib.ssa import AsyncSocket
-    from urllib3.exceptions import SecurityWarning
-    from urllib3.util.url import parse_url
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
-        AsyncBaseResolver,
-    )
-    from urllib3_future.contrib.ssa import AsyncSocket  # type: ignore[assignment]
-    from urllib3_future.exceptions import SecurityWarning  # type: ignore[assignment]
-    from urllib3_future.util.url import parse_url  # type: ignore[assignment]
-
 from .._typing import ProxyType
 from ..exceptions import RequestException, SSLError
 from ..models import PreparedRequest
+from ..packages.urllib3 import ConnectionInfo
+from ..packages.urllib3.contrib.resolver._async import AsyncBaseResolver
+from ..packages.urllib3.contrib.ssa import AsyncSocket
+from ..packages.urllib3.exceptions import SecurityWarning
+from ..packages.urllib3.util.url import parse_url
 from ._ocsp import (
     _parse_x509_der_cached,
     _str_fingerprint_of,

--- a/src/niquests/extensions/_ocsp.py
+++ b/src/niquests/extensions/_ocsp.py
@@ -20,22 +20,13 @@ from qh3._hazmat import (
     ReasonFlags,
 )
 
-from .._compat import HAS_LEGACY_URLLIB3
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ConnectionInfo
-    from urllib3.contrib.resolver import BaseResolver
-    from urllib3.exceptions import SecurityWarning
-    from urllib3.util.url import parse_url
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver import BaseResolver  # type: ignore[assignment]
-    from urllib3_future.exceptions import SecurityWarning  # type: ignore[assignment]
-    from urllib3_future.util.url import parse_url  # type: ignore[assignment]
-
 from .._typing import ProxyType
 from ..exceptions import RequestException, SSLError
 from ..models import PreparedRequest
+from ..packages.urllib3 import ConnectionInfo
+from ..packages.urllib3.contrib.resolver import BaseResolver
+from ..packages.urllib3.exceptions import SecurityWarning
+from ..packages.urllib3.util.url import parse_url
 from ._picotls import (
     ALERT,
     CHANGE_CIPHER,

--- a/src/niquests/extensions/_picotls.py
+++ b/src/niquests/extensions/_picotls.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 import hmac
 from hashlib import sha256
 
-from .._compat import HAS_LEGACY_URLLIB3
-
-if not HAS_LEGACY_URLLIB3:
-    from urllib3.util.url import _idna_encode
-else:
-    from urllib3_future.util.url import _idna_encode
+from ..packages.urllib3.util.url import _idna_encode
 
 LEGACY_TLS_VERSION = b"\x03\x03"
 TLS_AES_128_GCM_SHA256 = b"\x13\x01"

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -34,71 +34,6 @@ from urllib.parse import urlencode, urlsplit, urlunparse
 
 from charset_normalizer import from_bytes
 
-from ._compat import HAS_LEGACY_URLLIB3
-from ._vendor.kiss_headers import Headers, parse_it
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import (
-        AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3 import (
-        BaseHTTPResponse,
-        ConnectionInfo,
-        ResponsePromise,
-    )
-    from urllib3.contrib.webextensions import (
-        RawExtensionFromHTTP,
-        ServerSideEventExtensionFromHTTP,
-        WebSocketExtensionFromHTTP,
-    )
-    from urllib3.contrib.webextensions._async import (
-        AsyncRawExtensionFromHTTP,
-        AsyncServerSideEventExtensionFromHTTP,
-        AsyncWebSocketExtensionFromHTTP,
-    )
-    from urllib3.exceptions import (
-        DecodeError,
-        LocationParseError,
-        ProtocolError,
-        ReadTimeoutError,
-        SSLError,
-    )
-    from urllib3.fields import RequestField
-    from urllib3.filepost import choose_boundary, encode_multipart_formdata
-    from urllib3.util import parse_url
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import (  # type: ignore[assignment]
-        AsyncHTTPResponse as BaseAsyncHTTPResponse,
-    )
-    from urllib3_future import (  # type: ignore[assignment]
-        BaseHTTPResponse,
-        ConnectionInfo,
-        ResponsePromise,
-    )
-    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
-        RawExtensionFromHTTP,
-        ServerSideEventExtensionFromHTTP,
-        WebSocketExtensionFromHTTP,
-    )
-    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
-        AsyncRawExtensionFromHTTP,
-        AsyncServerSideEventExtensionFromHTTP,
-        AsyncWebSocketExtensionFromHTTP,
-    )
-    from urllib3_future.exceptions import (  # type: ignore[assignment]
-        DecodeError,
-        LocationParseError,
-        ProtocolError,
-        ReadTimeoutError,
-        SSLError,
-    )
-    from urllib3_future.fields import RequestField  # type: ignore[assignment]
-    from urllib3_future.filepost import (  # type: ignore[assignment]
-        choose_boundary,
-        encode_multipart_formdata,
-    )
-    from urllib3_future.util import parse_url  # type: ignore[assignment]
-
 from ._typing import (
     AsyncBodyType,
     AsyncHttpAuthenticationType,
@@ -114,6 +49,7 @@ from ._typing import (
     MultiPartFilesType,
     QueryParameterType,
 )
+from ._vendor.kiss_headers import Headers, parse_it
 from .auth import BearerTokenAuth, HTTPBasicAuth
 from .cookies import (
     RequestsCookieJar,
@@ -134,6 +70,34 @@ from .exceptions import (
 from .exceptions import JSONDecodeError as RequestsJSONDecodeError
 from .exceptions import SSLError as RequestsSSLError
 from .hooks import default_hooks
+from .packages.urllib3 import (
+    AsyncHTTPResponse as BaseAsyncHTTPResponse,
+)
+from .packages.urllib3 import (
+    BaseHTTPResponse,
+    ConnectionInfo,
+    ResponsePromise,
+)
+from .packages.urllib3.contrib.webextensions import (
+    RawExtensionFromHTTP,
+    ServerSideEventExtensionFromHTTP,
+    WebSocketExtensionFromHTTP,
+)
+from .packages.urllib3.contrib.webextensions._async import (
+    AsyncRawExtensionFromHTTP,
+    AsyncServerSideEventExtensionFromHTTP,
+    AsyncWebSocketExtensionFromHTTP,
+)
+from .packages.urllib3.exceptions import (
+    DecodeError,
+    LocationParseError,
+    ProtocolError,
+    ReadTimeoutError,
+    SSLError,
+)
+from .packages.urllib3.fields import RequestField
+from .packages.urllib3.filepost import choose_boundary, encode_multipart_formdata
+from .packages.urllib3.util import parse_url
 from .status_codes import codes
 from .structures import CaseInsensitiveDict
 from .utils import (
@@ -1395,7 +1359,7 @@ class Response:
             self.trailers = CaseInsensitiveDict(self.raw.trailers)
         # don't need to release the connection; that's been handled by urllib3
         # since we exhausted the data.
-        return self._content
+        return self._content  # type: ignore[return-value]
 
     @property
     def text(self) -> str | None:
@@ -1780,7 +1744,7 @@ class AsyncResponse(Response):
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3
         # since we exhausted the data.
-        return self._content
+        return self._content  # type: ignore[return-value]
 
     @property
     async def text(self) -> str | None:  # type: ignore[override]

--- a/src/niquests/packages.py
+++ b/src/niquests/packages.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+import typing
+
+from ._compat import HAS_LEGACY_URLLIB3
+
+# just to enable smooth type-completion!
+if typing.TYPE_CHECKING:
+    if HAS_LEGACY_URLLIB3:
+        import urllib3_future as urllib3  # noqa
+    else:
+        import urllib3  # type: ignore[no-redef]  # noqa
+
+    import charset_normalizer as chardet  # noqa
+
+    charset_normalizer = chardet  # noqa
+
+    import idna  # type: ignore[import-not-found]  # noqa
+
+# This code exists for backwards compatibility reasons.
+# I don't like it either. Just look the other way. :)
+for package in (
+    "urllib3",
+    "charset_normalizer",
+    "idna",
+    "chardet",
+):
+    try:
+        locals()[package] = __import__(package if package != "chardet" else "charset_normalizer")
+    except ImportError:
+        continue
+
+    # This traversal is apparently necessary such that the identities are
+    # preserved (requests.packages.urllib3.* is urllib3.*)
+    for mod in list(sys.modules):
+        if mod == package or mod.startswith(f"{package}."):
+            sys.modules[f"niquests.packages.{mod}"] = sys.modules[mod]

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -21,16 +21,6 @@ from http.cookiejar import CookieJar
 from urllib.parse import urljoin, urlparse
 
 from ._compat import HAS_LEGACY_URLLIB3, urllib3_ensure_type
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ConnectionInfo
-    from urllib3.contrib.webextensions import load_extension
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
-        load_extension,
-    )
-
 from ._constant import (
     DEFAULT_POOLSIZE,
     DEFAULT_RETRIES,
@@ -81,6 +71,8 @@ from .models import (  # noqa: F401
     Response,
     TransferProgress,
 )
+from .packages.urllib3 import ConnectionInfo
+from .packages.urllib3.contrib.webextensions import load_extension
 from .status_codes import codes
 from .structures import CaseInsensitiveDict, QuicSharedCache
 from .utils import (  # noqa: F401

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -33,48 +33,23 @@ from urllib.request import parse_http_list as _parse_list_header
 
 import wassima
 
-from ._compat import HAS_LEGACY_URLLIB3
-
-if HAS_LEGACY_URLLIB3 is False:
-    from urllib3 import ConnectionInfo
-    from urllib3.contrib.resolver import (
-        BaseResolver,
-        ManyResolver,
-        ProtocolResolver,
-        ResolverDescription,
-    )
-    from urllib3.contrib.resolver._async import (
-        AsyncBaseResolver,
-        AsyncManyResolver,
-        AsyncResolverDescription,
-    )
-    from urllib3.contrib.webextensions import ExtensionFromHTTP, load_extension
-    from urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP
-    from urllib3.util import make_headers, parse_url
-else:  # Defensive: tested in separate/isolated CI
-    from urllib3_future import ConnectionInfo  # type: ignore[assignment]
-    from urllib3_future.contrib.resolver import (  # type: ignore[assignment]
-        BaseResolver,
-        ManyResolver,
-        ProtocolResolver,
-        ResolverDescription,
-    )
-    from urllib3_future.contrib.resolver._async import (  # type: ignore[assignment]
-        AsyncBaseResolver,
-        AsyncManyResolver,
-        AsyncResolverDescription,
-    )
-    from urllib3_future.contrib.webextensions import (  # type: ignore[assignment]
-        ExtensionFromHTTP,
-        load_extension,
-    )
-    from urllib3_future.contrib.webextensions._async import (  # type: ignore[assignment]
-        AsyncExtensionFromHTTP,
-    )
-    from urllib3_future.util import make_headers, parse_url  # type: ignore[assignment]
-
 from .__version__ import __version__
 from .exceptions import InvalidURL, MissingSchema, UnrewindableBodyError
+from .packages.urllib3 import ConnectionInfo
+from .packages.urllib3.contrib.resolver import (
+    BaseResolver,
+    ManyResolver,
+    ProtocolResolver,
+    ResolverDescription,
+)
+from .packages.urllib3.contrib.resolver._async import (
+    AsyncBaseResolver,
+    AsyncManyResolver,
+    AsyncResolverDescription,
+)
+from .packages.urllib3.contrib.webextensions import ExtensionFromHTTP, load_extension
+from .packages.urllib3.contrib.webextensions._async import AsyncExtensionFromHTTP
+from .packages.urllib3.util import make_headers, parse_url
 from .structures import CaseInsensitiveDict
 
 if typing.TYPE_CHECKING:
@@ -1190,44 +1165,6 @@ def wrap_extension_for_http(
     This function purposely wrap the extension class to achieve that.
     Warning: synchronous context only!
     """
-    if HAS_LEGACY_URLLIB3 is False:
-        from urllib3.exceptions import (
-            ClosedPoolError,
-            DecodeError,
-            ProtocolError,
-            ReadTimeoutError,
-        )
-        from urllib3.exceptions import (
-            HTTPError as _HTTPError,
-        )
-        from urllib3.exceptions import (
-            InvalidHeader as _InvalidHeader,
-        )
-        from urllib3.exceptions import (
-            ProxyError as _ProxyError,
-        )
-        from urllib3.exceptions import (
-            SSLError as _SSLError,
-        )
-    else:
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            ClosedPoolError,
-            DecodeError,
-            ProtocolError,
-            ReadTimeoutError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            HTTPError as _HTTPError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            InvalidHeader as _InvalidHeader,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            ProxyError as _ProxyError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            SSLError as _SSLError,
-        )
 
     from .exceptions import (
         ChunkedEncodingError,
@@ -1239,6 +1176,24 @@ def wrap_extension_for_http(
     )
     from .exceptions import (
         SSLError as RequestsSSLError,
+    )
+    from .packages.urllib3.exceptions import (
+        ClosedPoolError,
+        DecodeError,
+        ProtocolError,
+        ReadTimeoutError,
+    )
+    from .packages.urllib3.exceptions import (
+        HTTPError as _HTTPError,
+    )
+    from .packages.urllib3.exceptions import (
+        InvalidHeader as _InvalidHeader,
+    )
+    from .packages.urllib3.exceptions import (
+        ProxyError as _ProxyError,
+    )
+    from .packages.urllib3.exceptions import (
+        SSLError as _SSLError,
     )
 
     class _WrappedExtensionFromHTTP(extension):  # type: ignore[valid-type,misc]
@@ -1303,44 +1258,6 @@ def async_wrap_extension_for_http(
     This function purposely wrap the extension class to achieve that.
     Warning: asynchronous context only!
     """
-    if HAS_LEGACY_URLLIB3 is False:
-        from urllib3.exceptions import (
-            ClosedPoolError,
-            DecodeError,
-            ProtocolError,
-            ReadTimeoutError,
-        )
-        from urllib3.exceptions import (
-            HTTPError as _HTTPError,
-        )
-        from urllib3.exceptions import (
-            InvalidHeader as _InvalidHeader,
-        )
-        from urllib3.exceptions import (
-            ProxyError as _ProxyError,
-        )
-        from urllib3.exceptions import (
-            SSLError as _SSLError,
-        )
-    else:
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            ClosedPoolError,
-            DecodeError,
-            ProtocolError,
-            ReadTimeoutError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            HTTPError as _HTTPError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            InvalidHeader as _InvalidHeader,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            ProxyError as _ProxyError,
-        )
-        from urllib3_future.exceptions import (  # type: ignore[assignment]
-            SSLError as _SSLError,
-        )
 
     from .exceptions import (
         ChunkedEncodingError,
@@ -1352,6 +1269,24 @@ def async_wrap_extension_for_http(
     )
     from .exceptions import (
         SSLError as RequestsSSLError,
+    )
+    from .packages.urllib3.exceptions import (
+        ClosedPoolError,
+        DecodeError,
+        ProtocolError,
+        ReadTimeoutError,
+    )
+    from .packages.urllib3.exceptions import (
+        HTTPError as _HTTPError,
+    )
+    from .packages.urllib3.exceptions import (
+        InvalidHeader as _InvalidHeader,
+    )
+    from .packages.urllib3.exceptions import (
+        ProxyError as _ProxyError,
+    )
+    from .packages.urllib3.exceptions import (
+        SSLError as _SSLError,
     )
 
     class _AsyncWrappedExtensionFromHTTP(extension):  # type: ignore[valid-type,misc]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -15,16 +15,16 @@ except ImportError:
 class TestLiveWebSocket:
     def test_sync_websocket_basic_example(self) -> None:
         with Session() as s:
-            resp = s.get("wss://echo.websocket.org")
+            resp = s.get("wss://httpbingo.org/websocket/echo")
 
             assert resp.status_code == 101
             assert resp.extension is not None
             assert resp.extension.closed is False
 
-            greeting_msg = resp.extension.next_payload()
-
-            assert greeting_msg is not None
-            assert isinstance(greeting_msg, str)
+            # greeting_msg = resp.extension.next_payload()
+            #
+            # assert greeting_msg is not None
+            # assert isinstance(greeting_msg, str)
 
             resp.extension.send_payload("Hello World")
             resp.extension.send_payload(b"Foo Bar Baz!")
@@ -38,16 +38,16 @@ class TestLiveWebSocket:
     @pytest.mark.asyncio
     async def test_async_websocket_basic_example(self) -> None:
         async with AsyncSession() as s:
-            resp = await s.get("wss://echo.websocket.org")
+            resp = await s.get("wss://httpbingo.org/websocket/echo")
 
             assert resp.status_code == 101
             assert resp.extension is not None
             assert resp.extension.closed is False
 
-            greeting_msg = await resp.extension.next_payload()
-
-            assert greeting_msg is not None
-            assert isinstance(greeting_msg, str)
+            # greeting_msg = await resp.extension.next_payload()
+            #
+            # assert greeting_msg is not None
+            # assert isinstance(greeting_msg, str)
 
             await resp.extension.send_payload("Hello World")
             await resp.extension.send_payload(b"Foo Bar Baz!")
@@ -60,16 +60,16 @@ class TestLiveWebSocket:
 
     def test_sync_websocket_read_timeout(self) -> None:
         with Session() as s:
-            resp = s.get("wss://echo.websocket.org", timeout=3)
+            resp = s.get("wss://httpbingo.org/websocket/echo", timeout=3)
 
             assert resp.status_code == 101
             assert resp.extension is not None
             assert resp.extension.closed is False
 
-            greeting_msg = resp.extension.next_payload()
-
-            assert greeting_msg is not None
-            assert isinstance(greeting_msg, str)
+            # greeting_msg = resp.extension.next_payload()
+            #
+            # assert greeting_msg is not None
+            # assert isinstance(greeting_msg, str)
 
             with pytest.raises(ReadTimeout):
                 resp.extension.next_payload()
@@ -80,16 +80,16 @@ class TestLiveWebSocket:
     @pytest.mark.asyncio
     async def test_async_websocket_read_timeout(self) -> None:
         async with AsyncSession() as s:
-            resp = await s.get("wss://echo.websocket.org", timeout=3)
+            resp = await s.get("wss://httpbingo.org/websocket/echo", timeout=3)
 
             assert resp.status_code == 101
             assert resp.extension is not None
             assert resp.extension.closed is False
-
-            greeting_msg = await resp.extension.next_payload()
-
-            assert greeting_msg is not None
-            assert isinstance(greeting_msg, str)
+            #
+            # greeting_msg = await resp.extension.next_payload()
+            #
+            # assert greeting_msg is not None
+            # assert isinstance(greeting_msg, str)
 
             with pytest.raises(ReadTimeout):
                 await resp.extension.next_payload()


### PR DESCRIPTION
3.13.1 (2025-03-09)
-------------------

**Added**
- Internal shortcut to urllib3-future as `niquests.packages.urllib3`. This immediately helps end-user migrating
  from Requests to Niquests and avoid the confusion around `urllib3` and `urllib3-future`.
  The package own code benefit from it. `idna`, `charset_normalizer` (+ aliased as `chardet`) can be used also.

**Misc**
- The documentation is improved. Especially around sync/async examples and migration snippets.
