### PR TITLE
Add missing await in AsyncResponse .close method

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1827,4 +1827,9 @@ class AsyncResponse(Response):
         if self.lazy:
             await self._gather()
 
-        super().close()
+        if self._content_consumed is False and self.raw is not None:
+            await self.raw.close()
+
+        release_conn = getattr(self.raw, "release_conn", None)
+        if release_conn is not None:
+            release_conn()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -130,6 +130,13 @@ class TestAsyncWithoutMultiplex:
             assert content
             assert "Herman Melville - Moby-Dick" in content
 
+    async def test_explicit_close_in_streaming_response(self) -> None:
+        async with AsyncSession() as s:
+            try:
+                r = await s.get("https://httpbingo.org/html", stream=True)
+            finally:
+                await r.close()
+
 
 @pytest.mark.usefixtures("requires_wan")
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi there,

Trying to explicitly call the `.close` method from an `AsyncResponse` produced by `AsyncSession` produces a runtime warning since the `close` method of urllib3's `AsyncHTTPResponse` is never awaited.

You can reproduce it with the following code
```python
import asyncio
import niquests

async def main():
    session = niquests.AsyncSession()
    try:
        response = await session.get("https://example.com", stream=True)
    finally:
        await response.close()

asyncio.run(main())
```

I'm not entirely sure if this is a bug but this at least gets rid of the runtime warning