### PR TITLE
Fixes issue where session hooks are not fired for the pre_request hook.

### DIFF
--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -871,7 +871,7 @@ class AsyncSession(Session):
 
         prep = await async_dispatch_hook(
             "pre_request",
-            hooks,  # type: ignore[arg-type]
+            prep.hooks,  # type: ignore[arg-type]
             prep,
         )
 

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -547,10 +547,11 @@ class Session:
             base_url=self.base_url,
         )
 
+        prep: PreparedRequest = self.prepare_request(req)
         prep: PreparedRequest = dispatch_hook(
             "pre_request",
-            hooks,  # type: ignore[arg-type]
-            self.prepare_request(req),
+            prep.hooks,  # type: ignore[arg-type]
+            prep,
         )
 
         assert prep.url is not None

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -548,7 +548,8 @@ class Session:
         )
 
         prep: PreparedRequest = self.prepare_request(req)
-        prep: PreparedRequest = dispatch_hook(
+
+        prep = dispatch_hook(
             "pre_request",
             prep.hooks,  # type: ignore[arg-type]
             prep,

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1117,6 +1117,28 @@ class TestRequests:
         assert prep.hooks["response"] != []
         assert prep.hooks["response"] == [hook]
 
+    def test_session_pre_request_fired(self, httpbin):
+        hook_called = False
+
+        def hook(*args, **kwargs):
+            nonlocal hook_called
+            hook_called = True
+
+        s = niquests.Session()
+        s.hooks["pre_request"] = [hook]
+
+        s.get(httpbin())
+
+        assert hook_called
+
+        hook_called = False
+
+        s.hooks["pre_request"] = []
+
+        s.get(httpbin(), hooks={"pre_request": [hook]})
+
+        assert hook_called
+
     def test_session_hooks_are_overridden_by_request_hooks(self, httpbin):
         def hook1(*args, **kwargs):
             pass


### PR DESCRIPTION
As this snippet showcases, niquests does not fire session hooks for the pre_request hook event.


```py
import niquests

def pre_request_session_hook(request: niquests.PreparedRequest):
    """Pre-request session hook."""
    print("Pre-request session hook fired")

s = niquests.Session()
s.hooks["pre_request"] = [pre_request_session_hook]
response = s.get("https://httpbin.org/get")
```

output
` `


This pull request modifies this behaviour for the expected one.