### PR TITLE
Release 3.14.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+3.14.1 (2025-04-19)
+-------------------
+
+**Fixed**
+- Prevent accessing lazy attr if it does not exist (e.g. requests_cache mixin) (#243)
+- Session hooks are not fired for the pre_request hook. (#242)
+- OCSP redundant calls made from session-less requests.
+
 3.14.0 (2025-03-30)
 -------------------
 

--- a/docs/dev/httpx.rst
+++ b/docs/dev/httpx.rst
@@ -236,6 +236,45 @@ HTTPX’s ``Client.build_request`` replaces Niquests’ ``Request.prepare()``::
     req = niquests.Request("GET", url)
     prepared = session.prepare_request(req)
 
+HTTP/2
+------
+
+HTTPX disable HTTP/2 by default and requires you to install an extra dependency to make it work.
+Whereas Niquests enable HTTP/2 AND HTTP/3 by default.
+
+.. note:: HTTPX don't support HTTP/3 by any official ways.
+
+To mimic HTTPX default behavior::
+
+    client = httpx.Client(http2=False)  # default value
+
+Do::
+
+    session = niquests.Session(disable_http2=True, disable_http3=True)
+
+With this, Niquests will ever only establish good old HTTP/1.1 requests.
+
+Async
+-----
+
+As HTTPX, Niquests does mirror its sync interfaces to async.
+
+For example::
+
+    session = niquests.Session()
+
+Becomes::
+
+    session = niquests.AsyncSession()
+
+And::
+
+    resp = niquests.get(...)
+
+Transforms to::
+
+    resp = await niquests.aget(...)
+
 Mocking & Testing
 -----------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.14.0"
+__version__ = "3.14.1"
 
-__build__: int = 0x031400
+__build__: int = 0x031401
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"


### PR DESCRIPTION
3.14.1 (2025-04-19)
-------------------

**Fixed**
- Prevent accessing lazy attr if it does not exist (e.g. requests_cache mixin) (#243)
- Session hooks are not fired for the pre_request hook. (#242)
- OCSP redundant calls made from session-less requests.
