### PR TITLE
Release 3.15.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,13 @@
 Release History
 ===============
 
-3.15.2 (2025-08-??)
+3.15.2 (2025-08-16)
 -------------------
 
 **Fixed**
 - The return type of `CaseInsensitiveDict.items()` could be a `list` instead of an expected `tuple`. (#276)
-- Fixed omitting hooks (keys) in `Session.hooks` dict causing an error at merge with request specific hooks.
+- Omitting hooks (keys) in `Session.hooks` dict causing an error at merge with request specific hooks.
+- CRL cache not persisted when pickling `Session`.
 
 3.15.1 (2025-08-13)
 -------------------

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.15.1"
+__version__ = "3.15.2"
 
-__build__: int = 0x031501
+__build__: int = 0x031502
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -339,6 +339,11 @@ class AsyncSession(Session):
                 keepalive_idle_window=self._keepalive_idle_window,
             ),
         )
+        for adapter in self.adapters.values():
+            if hasattr(adapter, "_ocsp_cache"):
+                adapter._ocsp_cache = self._ocsp_cache
+            if hasattr(adapter, "_crl_cache"):
+                adapter._crl_cache = self._crl_cache
 
     def mount(self, prefix: str, adapter: AsyncBaseAdapter) -> None:  # type: ignore[override]
         super().mount(prefix, adapter)  # type: ignore[arg-type]

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1487,8 +1487,12 @@ class Session:
         state = {attr: getattr(self, attr, None) for attr in self.__attrs__}
         if self._ocsp_cache is not None:
             state["_ocsp_cache"] = self._ocsp_cache
+        else:
+            state["_ocsp_cache"] = None
         if self._crl_cache is not None:
             state["_crl_cache"] = self._crl_cache
+        else:
+            state["_crl_cache"] = None
         return state
 
     def __setstate__(self, state):

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1485,12 +1485,10 @@ class Session:
 
     def __getstate__(self):
         state = {attr: getattr(self, attr, None) for attr in self.__attrs__}
-        if (
-            self._ocsp_cache is not None
-            and hasattr(self._ocsp_cache, "support_pickle")
-            and self._ocsp_cache.support_pickle() is True
-        ):
+        if self._ocsp_cache is not None:
             state["_ocsp_cache"] = self._ocsp_cache
+        if self._crl_cache is not None:
+            state["_crl_cache"] = self._crl_cache
         return state
 
     def __setstate__(self, state):
@@ -1538,6 +1536,11 @@ class Session:
                 keepalive_idle_window=self._keepalive_idle_window,
             ),
         )
+        for adapter in self.adapters.values():
+            if hasattr(adapter, "_ocsp_cache"):
+                adapter._ocsp_cache = self._ocsp_cache
+            if hasattr(adapter, "_crl_cache"):
+                adapter._crl_cache = self._crl_cache
 
     def get_redirect_target(self, resp: Response) -> str | None:
         """Receives a Response. Returns a redirect URI or ``None``"""


### PR DESCRIPTION
3.15.2 (2025-08-16)
-------------------

**Fixed**
- The return type of `CaseInsensitiveDict.items()` could be a `list` instead of an expected `tuple`. (#276)
- Omitting hooks (keys) in `Session.hooks` dict causing an error at merge with request specific hooks.
- CRL cache not persisted when pickling `Session`.
