### PR TITLE
fix: add overloads to `AsyncSession.send()` for stream-dependent return type

### DIFF
--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -451,14 +451,10 @@ class AsyncSession(Session):
         raise InvalidSchema(f"No connection adapters were found for {url!r}{additional_hint}")
 
     @typing.overload  # type: ignore[override]
-    async def send(
-        self, request: PreparedRequest, *, stream: Literal[True], **kwargs: typing.Any
-    ) -> AsyncResponse: ...
+    async def send(self, request: PreparedRequest, *, stream: Literal[True], **kwargs: typing.Any) -> AsyncResponse: ...
 
     @typing.overload  # type: ignore[override]
-    async def send(
-        self, request: PreparedRequest, **kwargs: typing.Any
-    ) -> Response: ...
+    async def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response: ...
 
     async def send(  # type: ignore[override]
         self, request: PreparedRequest, **kwargs: typing.Any


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
                        
  `AsyncSession.send()` returns `Response | AsyncResponse` without narrowing based on the `stream` parameter, unlike `request()`, `get()`, `post()`, and other public methods which already have `@overload` stubs.                
                                           
  ## Fix                                                                                                                                                                                                                           
                                                                                                                                                                                                                                   
  Adds `@typing.overload` stubs to `AsyncSession.send()` so the return type is narrowed based on `stream`:
  - `stream=True` → `AsyncResponse`
  - default → `Response`
