### PR TITLE
feat: add `auth` parameter to Session and AsyncSession `__init__`

### DIFF
--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -133,6 +133,7 @@ class AsyncSession(Session):
         base_url: str | None = None,
         timeout: TimeoutType | None = None,
         headers: HeadersType | None = None,
+        auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = None,
         hooks: AsyncHookType[PreparedRequest | Response | AsyncResponse] | None = None,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         app: ASGIApp | None = None,
@@ -158,7 +159,7 @@ class AsyncSession(Session):
 
         #: Default Authentication tuple or object to attach to
         #: :class:`Request <Request>`.
-        self.auth = None
+        self.auth = auth  # type: ignore[assignment]
 
         #: Dictionary mapping protocol or protocol and host to the URL of the proxy
         #: (e.g. {'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}) to

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -254,6 +254,7 @@ class Session:
         base_url: str | None = None,
         timeout: TimeoutType | None = None,
         headers: HeadersType | None = None,
+        auth: HttpAuthenticationType | None = None,
         hooks: HookType[PreparedRequest | Response] | None = None,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         app: WSGIApp | ASGIApp | None = None,
@@ -282,6 +283,7 @@ class Session:
         :param base_url: Automatically set a URL prefix (or base url) on every request emitted if applicable.
         :param timeout: Default timeout configuration to be used if no timeout is provided in exposed methods.
         :param headers: Default headers to be used on every request emitted.
+        :param auth: Default authentication tuple or object to attach to every request emitted.
         :param hooks: Default hooks to be used on every request emitted. Can be a dictionary mapping hook names to
             lists of callables, or a LifeCycleHook instance.
         :param revocation_configuration: How should that session do the certificate revocation check. Set it as None to disable
@@ -309,7 +311,7 @@ class Session:
 
         #: Default Authentication tuple or object to attach to
         #: :class:`Request <Request>`.
-        self.auth = None
+        self.auth = auth
 
         #: Dictionary mapping protocol or protocol and host to the URL of the proxy
         #: (e.g. {'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}) to

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -513,6 +513,30 @@ class TestRequests:
         s = niquests.Session(headers=init_headers)
         assert s.headers == expected_headers
 
+    @pytest.mark.parametrize(
+        "init_auth, expected_auth",
+        [
+            pytest.param(None, None, id="default-none"),
+            pytest.param(("user", "pass"), ("user", "pass"), id="basic-tuple"),
+        ],
+    )
+    def test_session_init_auth(self, init_auth, expected_auth):
+        """Session accepts custom auth at initialization."""
+        s = niquests.Session(auth=init_auth)
+        assert s.auth == expected_auth
+
+    @pytest.mark.parametrize(
+        "init_auth, expected_auth",
+        [
+            pytest.param(None, None, id="default-none"),
+            pytest.param(("user", "pass"), ("user", "pass"), id="basic-tuple"),
+        ],
+    )
+    def test_async_session_init_auth(self, init_auth, expected_auth):
+        """AsyncSession accepts custom auth at initialization."""
+        s = niquests.AsyncSession(auth=init_auth)
+        assert s.auth == expected_auth
+
     @pytest.mark.parametrize("key", ("User-agent", "user-agent"))
     def test_user_agent_transfers(self, httpbin, key):
         heads = {key: "Mozilla/5.0 (github.com/psf/requests)"}


### PR DESCRIPTION
Accept `auth` kwarg in `Session.__init__()` and `AsyncSession.__init__()`