### PR TITLE
fix: typo see to sse

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -407,7 +407,7 @@ class PreparedRequest:
             "wsgi",
             "ws",
             "wss",
-            "see",
+            "sse",
             "psse",
             "psse+unix",
             "ws+unix",


### PR DESCRIPTION
The prepare_url() scheme whitelist contained "see" instead of "sse", causing sse:// URLs to hit the           
early-return path that skips query parameter encoding, host normalization, and path processing.