### PR TITLE
Release 3.18.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.18.5 (2026-04-10)
+-------------------
+
+**Fixed**
+- sse scheme (web extension) urls preparation are skipped. (#372)
+
 3.18.4 (2026-04-02)
 -------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.18.4"
+__version__ = "3.18.5"
 
-__build__: int = 0x031804
+__build__: int = 0x031805
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"


### PR DESCRIPTION
3.18.5 (2026-04-10)
-------------------

**Fixed**
- sse scheme (web extension) urls preparation are skipped. (#372)
