### PR TITLE
Release 3.18.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.18.6 (2026-04-13)
+-------------------
+
+**Fixed**
+- AsyncResponse aenter is not awaitable. (#374)
+
 3.18.5 (2026-04-10)
 -------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.18.5"
+__version__ = "3.18.6"
 
-__build__: int = 0x031805
+__build__: int = 0x031806
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1678,7 +1678,10 @@ class AsyncResponse(Response):
             else None
         )
 
-    def __aenter__(self) -> AsyncResponse:  # type: ignore[override]
+    def __enter__(self) -> typing.Never:  # type: ignore[override]
+        raise NotImplementedError("AsyncResponse support only 'async with'")
+
+    async def __aenter__(self) -> AsyncResponse:  # type: ignore[override]
         return self
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -36,6 +36,13 @@ class TestAsyncWithoutMultiplex:
             assert resp.status_code == 200
             assert await resp.json()
 
+    async def test_awaitable_response_context(self):
+        async with AsyncSession() as s:
+            async with await s.get("https://httpbingo.org/get", stream=True) as resp:
+                assert resp.lazy is False
+                assert resp.status_code == 200
+                assert await resp.json()
+
     async def test_async_session_cookie_dummylock(self):
         async with AsyncSession() as s:
             await s.get("https://httpbingo.org/cookies/set?hello=world")


### PR DESCRIPTION
3.18.6 (2026-04-13)
-------------------

**Fixed**
- AsyncResponse aenter is not awaitable. (#374)
