### PR TITLE
Release 3.18.8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,15 @@
 Release History
 ===============
 
+3.18.8 (2026-05-10)
+-------------------
+
+**Fixed**
+- Avoid starting the background idle watcher/task in session-less requests.
+- `pre_request` hook not dispatched when passing through `Session.send`. (#389)
+- Repeated/redundant "is_ip_private" in CRL/OCSP algorithm. Now cached.
+- `Response.iter_content` inline typing definition missed allowing `None`. (#392)
+
 3.18.7 (2026-04-28)
 -------------------
 

--- a/docs/_static/analytics-events.css
+++ b/docs/_static/analytics-events.css
@@ -1,0 +1,67 @@
+/* "Was this helpful?" widget injected by analytics-events.js */
+.niq-feedback {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1.5rem 0 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-top: 1px solid var(--color-background-border, rgba(128, 128, 128, 0.25));
+    font-size: 0.85rem;
+    color: var(--color-foreground-muted, #666);
+    flex-wrap: wrap;
+}
+
+.niq-feedback__label {
+    margin-right: 0.25rem;
+}
+
+.niq-feedback__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 1.75rem;
+    padding: 0 0.5rem;
+    border: 1px solid var(--color-background-border, rgba(128, 128, 128, 0.35));
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.niq-feedback__btn:hover {
+    background: var(--color-background-hover, rgba(124, 77, 255, 0.08));
+    border-color: var(--color-brand-primary, #7C4DFF);
+    transform: translateY(-1px);
+}
+
+.niq-feedback__btn:focus-visible {
+    outline: 2px solid var(--color-brand-primary, #7C4DFF);
+    outline-offset: 2px;
+}
+
+.niq-feedback__ack {
+    margin-left: 0.5rem;
+    font-style: italic;
+    opacity: 0;
+    transition: opacity 200ms ease;
+}
+
+.niq-feedback--voted .niq-feedback__ack {
+    opacity: 1;
+}
+
+.niq-feedback--voted .niq-feedback__btn {
+    cursor: default;
+    opacity: 0.55;
+}
+
+.niq-feedback--up .niq-feedback__btn--up,
+.niq-feedback--down .niq-feedback__btn--down {
+    opacity: 1;
+    border-color: var(--color-brand-primary, #7C4DFF);
+    background: var(--color-background-hover, rgba(124, 77, 255, 0.12));
+}

--- a/docs/_static/analytics-events.js
+++ b/docs/_static/analytics-events.js
@@ -1,0 +1,340 @@
+/*
+ * Niquests docs — fine-grained GA4 event tracking.
+ *
+ * The default sphinxcontrib-googleanalytics extension only emits the implicit
+ * `page_view`. Static, anchor-driven docs barely produce any other signal,
+ * which makes it impossible to tell which sections, examples, or links are
+ * actually consumed.
+ *
+ * This script piggybacks on the existing gtag() instance and emits a handful
+ * of high-signal custom events:
+ *
+ *   - section_view   when an <h1..h4> with an id scrolls into view
+ *   - scroll_depth   at the 25 / 50 / 75 / 100 % milestones (once each)
+ *   - toc_click      when an in-page TOC / sidebar link is clicked
+ *   - anchor_click   when a heading permalink (¶) is clicked / copied
+ *   - code_copy      when a code block is copied via the Furo copy button
+ *   - outbound_click when a link to an external host is clicked
+ *   - section_feedback   when the reader rates a section helpful / not helpful
+ *
+ * All events are best-effort: they degrade silently if gtag or the matching
+ * DOM elements are unavailable.
+ */
+(function () {
+  "use strict";
+
+  function track(name, params) {
+    if (typeof window.gtag !== "function") {
+      return;
+    }
+    try {
+      window.gtag("event", name, params || {});
+    } catch (_) {
+      /* never break the page over analytics */
+    }
+  }
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  function pagePath() {
+    return location.pathname + location.search;
+  }
+
+  function trackSectionViews() {
+    if (!("IntersectionObserver" in window)) {
+      return;
+    }
+    var seen = new Set();
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          var el = entry.target;
+          var id = el.id || (el.parentElement && el.parentElement.id);
+          if (!id || seen.has(id)) {
+            return;
+          }
+          seen.add(id);
+          track("section_view", {
+            section_id: id,
+            section_title: (el.textContent || "").trim().slice(0, 120),
+            page_path: pagePath(),
+          });
+        });
+      },
+      { rootMargin: "0px 0px -60% 0px", threshold: 0.1 }
+    );
+
+    document
+      .querySelectorAll("article h1[id], article h2[id], article h3[id], article h4[id], section[id] > h1, section[id] > h2, section[id] > h3, section[id] > h4")
+      .forEach(function (el) {
+        observer.observe(el);
+      });
+  }
+
+  function trackScrollDepth() {
+    var milestones = [25, 50, 75, 100];
+    var fired = new Set();
+
+    function compute() {
+      var doc = document.documentElement;
+      var scrollTop = window.scrollY || doc.scrollTop || 0;
+      var viewport = window.innerHeight || doc.clientHeight;
+      var total = (doc.scrollHeight || document.body.scrollHeight) - viewport;
+      if (total <= 0) {
+        return 100;
+      }
+      return Math.min(100, Math.round((scrollTop / total) * 100));
+    }
+
+    var ticking = false;
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(function () {
+        var pct = compute();
+        milestones.forEach(function (m) {
+          if (pct >= m && !fired.has(m)) {
+            fired.add(m);
+            track("scroll_depth", {
+              percent_scrolled: m,
+              page_path: pagePath(),
+            });
+          }
+        });
+        ticking = false;
+      });
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+  }
+
+  // ---------------------------------------------------------------- click hooks
+  function trackClicks() {
+    document.addEventListener(
+      "click",
+      function (e) {
+        var a = e.target.closest && e.target.closest("a");
+        if (!a) return;
+
+        var href = a.getAttribute("href") || "";
+
+        // Heading permalink (¶)
+        if (a.classList.contains("headerlink")) {
+          var section = a.parentElement && a.parentElement.id;
+          track("anchor_click", {
+            section_id: section || href.replace(/^#/, ""),
+            page_path: pagePath(),
+          });
+          return;
+        }
+
+        // In-page TOC / sidebar links
+        if (href.startsWith("#")) {
+          track("toc_click", {
+            target_id: href.slice(1),
+            link_text: (a.textContent || "").trim().slice(0, 120),
+            page_path: pagePath(),
+          });
+          return;
+        }
+
+        // Outbound links
+        try {
+          var url = new URL(a.href, location.href);
+          if (url.host && url.host !== location.host) {
+            track("outbound_click", {
+              outbound_url: url.href,
+              outbound_host: url.host,
+              link_text: (a.textContent || "").trim().slice(0, 120),
+              page_path: pagePath(),
+            });
+          } else {
+            // Internal navigation (page-to-page)
+            if (url.pathname !== location.pathname) {
+              track("internal_nav", {
+                target_path: url.pathname,
+                link_text: (a.textContent || "").trim().slice(0, 120),
+                page_path: pagePath(),
+              });
+            }
+          }
+        } catch (_) {
+          /* ignore malformed hrefs */
+        }
+      },
+      true
+    );
+  }
+
+  // ---------------------------------------------------------------- code_copy
+  function trackCodeCopy() {
+    // Furo injects a <button class="copy"> inside <pre> blocks.
+    document.addEventListener(
+      "click",
+      function (e) {
+        var btn = e.target.closest && e.target.closest("button.copy, .copybtn");
+        if (!btn) return;
+
+        var pre = btn.closest("pre, div.highlight");
+        var lang = "";
+        if (pre) {
+          var cls = pre.className || "";
+          var m = cls.match(/highlight-(\w+)/) || cls.match(/language-(\w+)/);
+          if (m) lang = m[1];
+        }
+
+        // Find the nearest section heading for context.
+        var section = "";
+        var sec = btn.closest("section, article");
+        if (sec && sec.id) {
+          section = sec.id;
+        }
+
+        track("code_copy", {
+          language: lang || "unknown",
+          section_id: section,
+          page_path: pagePath(),
+        });
+      },
+      true
+    );
+  }
+
+  // Renders a tiny "Was this section helpful?" widget under every <h2> /
+  // <h3> heading and reports the verdict to GA. We keep a per-section flag
+  // in localStorage so a single visitor can't pollute the metric by spamming
+  // the buttons (one vote per section per browser).
+  function trackSectionFeedback() {
+    var STORAGE_KEY = "niquests-docs-feedback";
+    var store;
+    try {
+      store = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    } catch (_) {
+      store = {};
+    }
+
+    function persist() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+      } catch (_) {
+        /* private mode / quota exceeded — ignore */
+      }
+    }
+
+    function keyFor(sectionId) {
+      return location.pathname + "#" + sectionId;
+    }
+
+    function build(section) {
+      var sectionId = section.id;
+      if (!sectionId) return null;
+
+      var wrapper = document.createElement("div");
+      wrapper.className = "niq-feedback";
+      wrapper.setAttribute("data-section-id", sectionId);
+
+      var label = document.createElement("span");
+      label.className = "niq-feedback__label";
+      label.textContent = "Was this helpful?";
+
+      var up = document.createElement("button");
+      up.type = "button";
+      up.className = "niq-feedback__btn niq-feedback__btn--up";
+      up.setAttribute("aria-label", "Mark this section as helpful");
+      up.innerHTML = "<span aria-hidden=\"true\">\uD83D\uDC4D</span>";
+
+      var down = document.createElement("button");
+      down.type = "button";
+      down.className = "niq-feedback__btn niq-feedback__btn--down";
+      down.setAttribute("aria-label", "Mark this section as not helpful");
+      down.innerHTML = "<span aria-hidden=\"true\">\uD83D\uDC4E</span>";
+
+      var ack = document.createElement("span");
+      ack.className = "niq-feedback__ack";
+      ack.setAttribute("role", "status");
+
+      wrapper.appendChild(label);
+      wrapper.appendChild(up);
+      wrapper.appendChild(down);
+      wrapper.appendChild(ack);
+
+      function vote(value) {
+        var k = keyFor(sectionId);
+        if (store[k]) {
+          // Visitor already voted — let them change their mind silently
+          // but only emit a new event if the verdict actually flipped.
+          if (store[k] === value) {
+            return;
+          }
+        }
+        store[k] = value;
+        persist();
+
+        wrapper.classList.add("niq-feedback--voted");
+        wrapper.classList.toggle("niq-feedback--up", value === "up");
+        wrapper.classList.toggle("niq-feedback--down", value === "down");
+        ack.textContent =
+          value === "up" ? "Thanks for the feedback!" : "Thanks — we'll improve this.";
+
+        track("section_feedback", {
+          section_id: sectionId,
+          section_title: (function () {
+            var h = section.querySelector("h1, h2, h3, h4");
+            return h ? (h.textContent || "").replace(/¶$/, "").trim().slice(0, 120) : "";
+          })(),
+          verdict: value, // "up" | "down"
+          page_path: pagePath(),
+        });
+      }
+
+      up.addEventListener("click", function () {
+        vote("up");
+      });
+      down.addEventListener("click", function () {
+        vote("down");
+      });
+
+      // Restore prior vote (visual only — does NOT re-emit the event).
+      var prior = store[keyFor(sectionId)];
+      if (prior) {
+        wrapper.classList.add("niq-feedback--voted");
+        wrapper.classList.toggle("niq-feedback--up", prior === "up");
+        wrapper.classList.toggle("niq-feedback--down", prior === "down");
+        ack.textContent = "You already rated this section.";
+      }
+
+      return wrapper;
+    }
+
+    // Attach to every "real" content section (skip the page-level h1).
+    document
+      .querySelectorAll("article section section[id], article > section section[id]")
+      .forEach(function (section) {
+        // Only attach to sections whose first child is an h2/h3 heading —
+        // i.e. genuine content sections, not arbitrary anchored wrappers.
+        var heading = section.querySelector(":scope > h2, :scope > h3");
+        if (!heading) return;
+        var widget = build(section);
+        if (!widget) return;
+        section.appendChild(widget);
+      });
+  }
+
+  ready(function () {
+    trackSectionViews();
+    trackScrollDepth();
+    trackClicks();
+    trackCodeCopy();
+    trackSectionFeedback();
+  });
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,12 @@ html_theme_options = {
 }
 
 html_js_files = [
-    'https://unpkg.com/@terminhtml/bootstrap@1.x/dist/@terminhtml-bootstrap.umd.js'
+    'https://unpkg.com/@terminhtml/bootstrap@1.x/dist/@terminhtml-bootstrap.umd.js',
+    'analytics-events.js',
+]
+
+html_css_files = [
+    'analytics-events.css',
 ]
 
 googleanalytics_id = "G-F8C2DJ1CJN"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,8 @@ filterwarnings = [
     '''ignore:Passing bytes as a header value is deprecated and will:DeprecationWarning''',
     '''ignore:The 'JSONIFY_PRETTYPRINT_REGULAR' config key is deprecated and will:DeprecationWarning''',
     '''ignore:unclosed .*:ResourceWarning''',
-
     '''ignore:A plugin raised an exception during an old-style hookwrapper teardown''',
+    '''ignore:.*is required to prevent decompression bombs.*''',
     '''ignore:.*:pytest.PytestUnraisableExceptionWarning''',
     '''ignore:.*iscoroutinefunction.*:DeprecationWarning''',
     '''ignore:.*get_event_loop.*:DeprecationWarning''',

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.18.7"
+__version__ = "3.18.8"
 
-__build__: int = 0x031807
+__build__: int = 0x031808
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -113,7 +113,7 @@ def request(
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
     global _SHARED_OCSP_CACHE, _SHARED_CRL_CACHE
-    with sessions.Session(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries) as session:
+    with sessions.Session(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None) as session:
         session._ocsp_cache = _SHARED_OCSP_CACHE
         session._crl_cache = _SHARED_CRL_CACHE
         try:

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -113,7 +113,9 @@ def request(
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
     global _SHARED_OCSP_CACHE, _SHARED_CRL_CACHE
-    with sessions.Session(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None) as session:
+    with sessions.Session(
+        quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None
+    ) as session:
         session._ocsp_cache = _SHARED_OCSP_CACHE
         session._crl_cache = _SHARED_CRL_CACHE
         try:

--- a/src/niquests/async_api.py
+++ b/src/niquests/async_api.py
@@ -159,7 +159,9 @@ async def request(
     # By using the 'with' statement we are sure the session is closed, thus we
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
-    async with AsyncSession(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None) as session:
+    async with AsyncSession(
+        quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None
+    ) as session:
         session._ocsp_cache = _SHARED_OCSP_CACHE.get()
         session._crl_cache = _SHARED_CRL_CACHE.get()
         try:

--- a/src/niquests/async_api.py
+++ b/src/niquests/async_api.py
@@ -159,7 +159,7 @@ async def request(
     # By using the 'with' statement we are sure the session is closed, thus we
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
-    async with AsyncSession(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries) as session:
+    async with AsyncSession(quic_cache_layer=_SHARED_QUIC_CACHE, retries=retries, keepalive_delay=None, keepalive_idle_window=None) as session:
         session._ocsp_cache = _SHARED_OCSP_CACHE.get()
         session._crl_cache = _SHARED_CRL_CACHE.get()
         try:

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -511,6 +511,16 @@ class AsyncSession(Session):
         stream = kwargs.get("stream")
         hooks = request.hooks
 
+        # Dispatch the pre_request hook here so it fires regardless of whether
+        # the user came in through AsyncSession.request() or called
+        # AsyncSession.send() directly with a manually prepared PreparedRequest.
+        # see https://github.com/jawah/niquests/issues/389
+        request = await async_dispatch_hook(  # type: ignore[assignment]
+            "pre_request",
+            hooks,  # type: ignore[arg-type]
+            request,
+        )
+
         ptr_request = request
 
         async def on_post_connection(conn_info: ConnectionInfo) -> None:
@@ -1053,12 +1063,6 @@ class AsyncSession(Session):
                 prep._body_position = await prep.body.tell()
             except OSError:
                 pass
-
-        prep = await async_dispatch_hook(
-            "pre_request",
-            prep.hooks,  # type: ignore[arg-type]
-            prep,
-        )
 
         assert prep.url is not None
 

--- a/src/niquests/extensions/revocation/_crl/__init__.py
+++ b/src/niquests/extensions/revocation/_crl/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-import ipaddress
 import ssl
 import threading
 import typing
@@ -20,6 +19,7 @@ from ....packages.urllib3 import ConnectionInfo
 from ....packages.urllib3.contrib.resolver import BaseResolver
 from ....packages.urllib3.exceptions import SecurityWarning
 from ....typing import ProxyType
+from ....utils import is_private_ip
 from .._ocsp import _parse_x509_der_cached, _str_fingerprint_of, readable_revocation_reason
 
 
@@ -195,7 +195,7 @@ def verify(
     # they use a cert that IS NOT in the chain
     # to sign the response. It's weird but true.
     # see https://github.com/jawah/niquests/issues/274
-    ignore_signature_without_strict = ipaddress.ip_address(conn_info.destination_address[0]).is_private or bool(proxies)
+    ignore_signature_without_strict = is_private_ip(conn_info.destination_address[0]) or bool(proxies)
     verify_signature = strict is True or ignore_signature_without_strict is False
 
     peer_certificate: Certificate = _parse_x509_der_cached(conn_info.certificate_der)

--- a/src/niquests/extensions/revocation/_crl/_async/__init__.py
+++ b/src/niquests/extensions/revocation/_crl/_async/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import ipaddress
 import ssl
 import typing
 import warnings
@@ -20,7 +19,7 @@ from .....packages.urllib3 import ConnectionInfo
 from .....packages.urllib3.contrib.resolver._async import AsyncBaseResolver
 from .....packages.urllib3.exceptions import SecurityWarning
 from .....typing import ProxyType
-from .....utils import is_cancelled_error_root_cause
+from .....utils import is_cancelled_error_root_cause, is_private_ip
 from ..._ocsp import _parse_x509_der_cached, _str_fingerprint_of, readable_revocation_reason
 
 
@@ -185,7 +184,7 @@ async def verify(
     # they use a cert that IS NOT in the chain
     # to sign the response. It's weird but true.
     # see https://github.com/jawah/niquests/issues/274
-    ignore_signature_without_strict = ipaddress.ip_address(conn_info.destination_address[0]).is_private or bool(proxies)
+    ignore_signature_without_strict = is_private_ip(conn_info.destination_address[0]) or bool(proxies)
     verify_signature = strict is True or ignore_signature_without_strict is False
 
     peer_certificate: Certificate = _parse_x509_der_cached(conn_info.certificate_der)

--- a/src/niquests/extensions/revocation/_ocsp/__init__.py
+++ b/src/niquests/extensions/revocation/_ocsp/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-import ipaddress
 import ssl
 import threading
 import typing
@@ -26,6 +25,7 @@ from ....packages.urllib3 import ConnectionInfo
 from ....packages.urllib3.contrib.resolver import BaseResolver
 from ....packages.urllib3.exceptions import SecurityWarning
 from ....typing import ProxyType
+from ....utils import is_private_ip
 
 
 @lru_cache(maxsize=64)
@@ -255,7 +255,7 @@ def verify(
     # they use a cert that IS NOT in the chain
     # to sign the response. It's weird but true.
     # see https://github.com/jawah/niquests/issues/274
-    ignore_signature_without_strict = ipaddress.ip_address(conn_info.destination_address[0]).is_private or bool(proxies)
+    ignore_signature_without_strict = is_private_ip(conn_info.destination_address[0]) or bool(proxies)
     verify_signature = strict is True or ignore_signature_without_strict is False
 
     peer_certificate = _parse_x509_der_cached(conn_info.certificate_der)

--- a/src/niquests/extensions/revocation/_ocsp/_async/__init__.py
+++ b/src/niquests/extensions/revocation/_ocsp/_async/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import ipaddress
 import ssl
 import typing
 import warnings
@@ -23,7 +22,7 @@ from .....packages.urllib3 import ConnectionInfo
 from .....packages.urllib3.contrib.resolver._async import AsyncBaseResolver
 from .....packages.urllib3.exceptions import SecurityWarning
 from .....typing import ProxyType
-from .....utils import is_cancelled_error_root_cause
+from .....utils import is_cancelled_error_root_cause, is_private_ip
 from .. import (
     _parse_x509_der_cached,
     _str_fingerprint_of,
@@ -265,7 +264,7 @@ async def verify(
         # they use a cert that IS NOT in the chain
         # to sign the response. It's weird but true.
         # see https://github.com/jawah/niquests/issues/274
-        ignore_signature_without_strict = ipaddress.ip_address(conn_info.destination_address[0]).is_private or bool(proxies)
+        ignore_signature_without_strict = is_private_ip(conn_info.destination_address[0]) or bool(proxies)
         verify_signature = strict is True or ignore_signature_without_strict is False
 
         # why are we doing this twice?

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1161,14 +1161,16 @@ class Response:
 
     @typing.overload
     def iter_content(
-        self, chunk_size: int = ..., decode_unicode: Literal[False] = ...
+        self, chunk_size: int | None = ..., decode_unicode: Literal[False] = ...
     ) -> typing.Generator[bytes, None, None]: ...
 
     @typing.overload
-    def iter_content(self, chunk_size: int = ..., *, decode_unicode: Literal[True]) -> typing.Generator[str, None, None]: ...
+    def iter_content(
+        self, chunk_size: int | None = ..., *, decode_unicode: Literal[True]
+    ) -> typing.Generator[str, None, None]: ...
 
     def iter_content(
-        self, chunk_size: int = ITER_CHUNK_SIZE, decode_unicode: bool = False
+        self, chunk_size: int | None = ITER_CHUNK_SIZE, decode_unicode: bool = False
     ) -> typing.Generator[bytes | str, None, None]:
         """Iterates over the response data.  When stream=True is set on the
         request, this avoids reading the content at once into memory for
@@ -1707,16 +1709,16 @@ class AsyncResponse(Response):
 
     @typing.overload  # type: ignore[override]
     async def iter_content(
-        self, chunk_size: int = ..., decode_unicode: Literal[False] = ...
+        self, chunk_size: int | None = ..., decode_unicode: Literal[False] = ...
     ) -> typing.AsyncGenerator[bytes, None]: ...
 
     @typing.overload  # type: ignore[override]
     async def iter_content(
-        self, chunk_size: int = ..., *, decode_unicode: Literal[True]
+        self, chunk_size: int | None = ..., *, decode_unicode: Literal[True]
     ) -> typing.AsyncGenerator[str, None]: ...
 
     async def iter_content(  # type: ignore[override]
-        self, chunk_size: int = ITER_CHUNK_SIZE, decode_unicode: bool = False
+        self, chunk_size: int | None = ITER_CHUNK_SIZE, decode_unicode: bool = False
     ) -> typing.AsyncGenerator[bytes | str, None]:
         if self.lazy:
             await self._gather()

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -643,12 +643,6 @@ class Session:
 
         prep: PreparedRequest = self.prepare_request(req)
 
-        prep = dispatch_hook(
-            "pre_request",
-            prep.hooks,  # type: ignore[arg-type]
-            prep,
-        )
-
         assert prep.url is not None
 
         proxies = proxies or {}
@@ -1213,6 +1207,16 @@ class Session:
         allow_redirects = kwargs.pop("allow_redirects", True)
         stream = kwargs.get("stream")
         hooks = request.hooks
+
+        # Dispatch the pre_request hook here so it fires regardless of whether
+        # the user came in through Session.request() or called Session.send()
+        # directly with a manually prepared PreparedRequest.
+        # see https://github.com/jawah/niquests/issues/389
+        request = dispatch_hook(  # type: ignore[assignment]
+            "pre_request",
+            hooks,  # type: ignore[arg-type]
+            request,
+        )
 
         ptr_request = request
 

--- a/src/niquests/structures.py
+++ b/src/niquests/structures.py
@@ -80,6 +80,8 @@ class CaseInsensitiveDict(MutableMapping):
 
     def __init__(self, data=None, **kwargs) -> None:
         self._store: MutableMapping[bytes | str, tuple[bytes | str, ...]] = {}
+        if data is None and not kwargs:
+            return
         if data is None:
             data = {}
 
@@ -88,15 +90,14 @@ class CaseInsensitiveDict(MutableMapping):
             self._store = data._container.copy()
         elif isinstance(data, CaseInsensitiveDict):
             self._store = data._store.copy()  # type: ignore[attr-defined]
-        else:  # otherwise, we must ensure given iterable contains type we can rely on
-            if data or kwargs:
-                if hasattr(data, "items"):
-                    self.update(data, **kwargs)
-                else:
-                    self.update(
-                        {k: v for k, v in data},
-                        **kwargs,
-                    )
+        elif data or kwargs:  # otherwise, we must ensure given iterable contains type we can rely on
+            if hasattr(data, "items"):
+                self.update(data, **kwargs)
+            else:
+                self.update(
+                    {k: v for k, v in data},
+                    **kwargs,
+                )
 
     def __setitem__(self, key: str | bytes, value: str | bytes) -> None:
         # Use the lowercased key for lookups, but store the actual

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -12,6 +12,7 @@ import asyncio
 import codecs
 import contextlib
 import io
+import ipaddress
 import os
 import re
 import socket
@@ -578,6 +579,13 @@ def _get_mask_bits(mask: int, totalbits: int = 32) -> int:
     bits = ((1 << mask) - 1) << (totalbits - mask)
 
     return bits
+
+
+@lru_cache(maxsize=256)
+def is_private_ip(addr: str) -> bool:
+    """Cached check for whether an IP address is private. Avoids repeated
+    ``ipaddress.ip_address()`` construction which is expensive, especially for IPv6."""
+    return ipaddress.ip_address(addr).is_private
 
 
 def address_in_network(ip: str, net: str) -> bool:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -155,6 +155,33 @@ class TestAsyncWithoutMultiplex:
 
                 assert r.request._body_position == 0
 
+    async def test_pre_request_fired_on_send(self):
+        """Regression: pre_request must also fire when calling
+        AsyncSession.send() directly with a manually-prepared PreparedRequest
+        (jawah/niquests#389)."""
+        import niquests
+
+        call_count = 0
+
+        def hook(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+        async with AsyncSession() as s:
+            req = niquests.Request(
+                "GET",
+                "https://httpbingo.org/get",
+                hooks={"pre_request": [hook]},
+            )
+            await s.send(req.prepare())
+
+            assert call_count == 1
+
+            # Ensure no double-dispatch through the high-level API.
+            call_count = 0
+            await s.get("https://httpbingo.org/get", hooks={"pre_request": [hook]})
+            assert call_count == 1
+
 
 @pytest.mark.usefixtures("requires_wan")
 @pytest.mark.asyncio

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1173,6 +1173,28 @@ class TestRequests:
 
         assert hook_called
 
+    def test_session_pre_request_fired_on_send(self, httpbin):
+        """Regression: pre_request must also fire when calling Session.send()
+        directly with a manually-prepared PreparedRequest (jawah/niquests#389)."""
+        call_count = 0
+
+        def hook(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+        s = niquests.Session()
+
+        req = niquests.Request("GET", httpbin(), hooks={"pre_request": [hook]})
+        s.send(req.prepare())
+
+        assert call_count == 1
+
+        # And ensure it still fires exactly once through the high-level API
+        # (i.e. no double-dispatch regression).
+        call_count = 0
+        s.get(httpbin(), hooks={"pre_request": [hook]})
+        assert call_count == 1
+
     def test_session_hooks_are_overridden_by_request_hooks(self, httpbin):
         def hook1(*args, **kwargs):
             pass


### PR DESCRIPTION
3.18.8 (2026-05-10)
-------------------

**Fixed**
- Avoid starting the background idle watcher/task in session-less requests.
- `pre_request` hook not dispatched when passing through `Session.send`. (#389)
- Repeated/redundant "is_ip_private" in CRL/OCSP algorithm. Now cached.
- `Response.iter_content` inline typing definition missed allowing `None`. (#392)
