### PR TITLE
type annotation for int, float and bool in query params

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution Guidelines
 
 Before opening any issues or proposing any pull requests, please read
-our [Contributor's Guide](https://requests.readthedocs.io/en/latest/dev/contributing/).
+our [Contributor's Guide](https://niquests.readthedocs.io/en/latest/dev/contributing.html).
 
 To get the greatest chance of helpful responses, please also observe the
 following additional notes.
@@ -9,9 +9,9 @@ following additional notes.
 ## Questions
 
 The GitHub issue tracker is for *bug reports* and *feature requests*. Please do
-not use it to ask questions about how to use Requests. These questions should
+not use it to ask questions about how to use Niquests. These questions should
 instead be directed to [Stack Overflow](https://stackoverflow.com/). Make sure
-that your question is tagged with the `python-requests` tag when asking it on
+that your question is tagged with the `python`, `python-niquests` and/or `python-requests` tags when asking it on
 Stack Overflow, to ensure that it is answered promptly and accurately.
 
 ## Good Bug Reports
@@ -44,9 +44,9 @@ Please be aware of the following things when filing bug reports:
      doesn't work" or "it fails". Tell us *how* it fails: do you get an
      exception? A hang? A non-200 status code? How was the actual result
      different from your expected result?
-   - Tell us **what version of Requests you're using**, and
-     **how you installed it**. Different versions of Requests behave
-     differently and have different bugs, and some distributors of Requests
+   - Tell us **what version of Niquests you're using**, and
+     **how you installed it**. Different versions of Niquests behave
+     differently and have different bugs, and some distributors of Niquests
      ship patches on top of the code we supply.
 
    If you do not provide all of these things, it will take us much longer to

--- a/src/niquests/typing.py
+++ b/src/niquests/typing.py
@@ -28,8 +28,8 @@ if typing.TYPE_CHECKING:
 HttpMethodType: typing.TypeAlias = str
 #: List of formats accepted for URL queries parameters. (e.g. /?param1=a&param2=b)
 QueryParameterType: typing.TypeAlias = typing.Union[
-    typing.List[typing.Tuple[str, typing.Union[str, typing.List[str], None]]],
-    typing.Mapping[str, typing.Union[str, typing.List[str], None]],
+    typing.List[typing.Tuple[str, typing.Union[str, typing.List[str], int, float, bool, None]]],
+    typing.Mapping[str, typing.Union[str, typing.List[str], int, float, bool, None]],
     bytes,
     str,
 ]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2942,3 +2942,30 @@ class TestPreparingURLs:
         r = niquests.get(httpbin("get"))
         assert r.http_version is not None
         assert r.http_version == 11
+
+
+    def test_encode_params_supports_int_values(self):
+        assert PreparedRequest._encode_params({"key": 42}) == "key=42"
+
+    def test_encode_params_supports_float_values(self):
+        assert PreparedRequest._encode_params({"key": 4.2}) == "key=4.2"
+
+    def test_encode_params_supports_bool_values(self):
+        assert PreparedRequest._encode_params({"key": True}) == "key=True"
+
+
+    def test_prepare_url_supports_int_params(self):
+        p = PreparedRequest()
+        p.prepare_url("https://example.com", {"key": 42})
+        assert p.url == "https://example.com/?key=42"
+
+    def test_prepare_url_supports_float_params(self):
+        p = PreparedRequest()
+        p.prepare_url("https://example.com", {"key": 4.2})
+        assert p.url == "https://example.com/?key=4.2"
+
+    def test_prepare_url_supports_bool_params(self):
+        p = PreparedRequest()
+        p.prepare_url("https://example.com", {"key": True})
+        assert p.url == "https://example.com/?key=True"
+


### PR DESCRIPTION
Hello, 

I was having weird type annotation errors while using niquests
and turns out the type annotation for int, float and bool types don't exist in the QueryParameters

this is what I mean vs requests

<img width="1107" height="706" alt="image" src="https://github.com/user-attachments/assets/20ca536c-740a-490e-912c-98f8a595ba34" />

so I followed it up inside the library, and I found it's not officially supported

in `models.py` line 751
<img width="1534" height="140" alt="image" src="https://github.com/user-attachments/assets/32b791b2-307c-4d69-b60d-501a00f96ae6" />

so I'm not sure if it's okay to be added to the supported types or not, so feel free to accept or refuse the pr, but I added tests for it

requests supported param value types
```

_ParamsMappingValueType: TypeAlias = (
        str | bytes | int | float | Iterable[str | bytes | int | float] | None
    )
```
vs
niquests supported param value types
```
QueryParameterType: typing.TypeAlias = typing.Union[
    typing.List[typing.Tuple[str, typing.Union[str, typing.List[str], None]]],
    typing.Mapping[str, typing.Union[str, typing.List[str], None]],
    bytes,
    str,
]
```
Thanks

p.s: 
1 - the request worked anyway even with the type annotation error

2 - int and float aren't a huge thing to think over, only thing I'm not sure about is the bool True and False are encoded to "True" and "False" while most languages I know read the boolean values as "true" and "false", I only tested it versus fastapi server,  and it was read as the bool value True, not sure if other frameworks behave the same