### PR TITLE
Release 3.19

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,55 @@
 Release History
 ===============
 
+3.19.0 (2026-06-01)
+-------------------
+
+**Added**
+- `Session` and `AsyncSession` constructors now accept `params`, `cookies`, `proxies`, `verify` and `cert`
+  so that per-request defaults can be configured at initialization, consistently with `headers` and `auth`. (#400)
+  Ease forward the migration from httpx for interested users.
+- A plain `http.cookiejar.CookieJar` (or a mapping) provided as `cookies` is now coerced into a
+  `RequestsCookieJar`. The `Session`/`AsyncSession` constructor always coerces (so `session.cookies.set(...)`
+  works), while at the request level an unknown `CookieJar` subclass (e.g. `MozillaCookieJar` or any
+  file-backed/custom jar) is left untouched to preserve its behavior. (#401, #404)
+- Support for the alternative TLS backend BoringSSL via the `utls` extra.
+  Niquests now offer a first-class TLS browser impersonation without ever-changing your http client.
+  It is automatically done (e.g. negotiated) once the extra is installed. You will need to keep it
+  regularly updated so that you have the latest TLS specs of modern browsers.
+- `Session` and `AsyncSession` constructors now accept `allow_incoming_cookies` (defaults to `True`).
+  Set it to `False` to ignore every cookie sent by the remote peer (via `Set-Cookie`) so that nothing
+  is merged into the session jar, including cookies carried across redirect hops. Outgoing cookies you
+  set yourself are still emitted.
+- `Session.request`/`AsyncSession.request` (and the verb shortcuts) now accept an `override_scheme`
+  keyword argument. When a `base_url` is set on the Session, it override the scheme of the final
+  (merged) URL just before the adapter is picked, so you can target a different scheme (e.g. `sse`,
+  `ws`/`wss`, optionally with an implementation suffix like `sse+unix`) without retyping the full URL. (#325)
+
+**Changed**
+- The `cookies` attribute of `Session`, `AsyncSession` and `Response` is now always typed as
+  `RequestsCookieJar` instead of `RequestsCookieJar | CookieJar`. This restores the ergonomic mapping
+  interface (e.g. `session.cookies.set(...)`) when using static type checkers. (#401, #404)
+
+  This is **not** a runtime breaking change: reading `.cookies` is unchanged, and a native `CookieJar`
+  is still accepted everywhere it is passed as an argument (it is coerced when relevant). We do,
+  however, acknowledge a static-typing trade-off: assigning a custom/non-`RequestsCookieJar` jar
+  directly to the attribute (e.g. `session.cookies = MozillaCookieJar(...)`) now makes type checkers
+  such as mypy complain, since the attribute is annotated as `RequestsCookieJar`. The assignment keeps
+  working at runtime; if you rely on it, add a `# type: ignore`. We chose narrowing on
+  purpose the predominant path is that `RequestsCookieJar` is expected while subclasses (custom implementation)
+  are a niche usage.
+- `CaseInsensitiveDict` is now generic over its key and value types (`CaseInsensitiveDict[_KT, _VT]`,
+  mirroring `dict`/`Mapping`), and `Response.headers`/`Response.trailers` are typed as
+  `CaseInsensitiveDict[str, str]`. Reading a response header (e.g. `response.headers["Content-Type"]`)
+  now yields `str` instead of `str | bytes`, removing the need for a `cast`/`assert` to use the headers
+  as a plain string mapping with static type checkers. (#401)
+
+  This is purely a typing improvement with **no runtime change**: the class still subclasses
+  `collections.abc.MutableMapping` (it merely also gains `typing.Generic`), so the Python 3.7 floor and
+  the existing behavior are preserved, and no new dependency is introduced. Unsubscripted
+  `CaseInsensitiveDict` keeps its historical `str | bytes` key/value types, so existing annotations are
+  unaffected.
+
 3.18.8 (2026-05-10)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -25,43 +25,45 @@ Niquests, is the “**Safest**, **Fastest[^10]**, **Easiest**, and **Most advanc
 <details>
   <summary>👆 <b>Look at the feature table comparison</b> against <i>requests, httpx and aiohttp</i>!</summary>
 
-| Feature                                    |      niquests      | requests  |     httpx     | aiohttp       |
-|--------------------------------------------|:------------------:|:---------:|:-------------:|---------------|
-| `HTTP/1.1`                                 |         ✅          |     ✅     |       ✅       | ✅             |
-| `HTTP/2`                                   |         ✅          |     ❌     |     ✅[^7]     | ❌             |
-| `HTTP/3 over QUIC`                         |         ✅          |     ❌     |       ❌       | ❌             |
-| `Synchronous`                              |         ✅          |     ✅     |       ✅       | _N/A_[^1]     |
-| `Asynchronous`                             |         ✅          |     ❌     |       ✅       | ✅             |
-| `Thread Safe`                              |         ✅          |     ✅     |     ❌[^5]     | _N/A_[^1]     |
-| `Task Safe`                                |         ✅          | _N/A_[^2] |       ✅       | ✅             |
-| `OS Trust Store`                           |         ✅          |     ❌     |       ❌       | ❌             |
-| `Multiplexing`                             |         ✅          |     ❌     | _Limited_[^3] | ❌             |
-| `DNSSEC`                                   |       ✅[^11]       |     ❌     |       ❌       | ❌             |
-| `Customizable DNS Resolution`              |         ✅          |     ❌     |       ❌       | ✅             |
-| `DNS over HTTPS`                           |         ✅          |     ❌     |       ❌       | ❌             |
-| `DNS over QUIC`                            |         ✅          |     ❌     |       ❌       | ❌             |
-| `DNS over TLS`                             |         ✅          |     ❌     |       ❌       | ❌             |
-| `Multiple DNS Resolver`                    |         ✅          |     ❌     |       ❌       | ❌             |
-| `Network Fine Tuning & Inspect`            |         ✅          |     ❌     | _Limited_[^6] | _Limited_[^6] |
-| `Certificate Revocation Protection`        |         ✅          |     ❌     |       ❌       | ❌             |
-| `Session Persistence`                      |         ✅          |     ✅     |       ✅       | ✅             |
-| `In-memory Certificate CA & mTLS`          |         ✅          |     ❌     | _Limited_[^4] | _Limited_[^4] |
-| `SOCKS 4/5 Proxies`                        |         ✅          |     ✅     |       ✅       | ❌             |
-| `HTTP/HTTPS Proxies`                       |         ✅          |     ✅     |       ✅       | ✅             |
-| `TLS-in-TLS Support`                       |         ✅          |     ✅     |       ✅       | ✅             |
-| `Direct HTTP/3 Negotiation`                |       ✅[^9]        |  N/A[^8]  |    N/A[^8]    | N/A[^8]       |
-| `Happy Eyeballs`                           |         ✅          |     ❌     |       ❌       | ✅             |
-| `Package / SLSA Signed`                    |         ✅          |     ❌     |       ❌       | ✅             |
-| `HTTP/2 with prior knowledge (h2c)`        |         ✅          |     ❌     |       ✅       | ❌             |
-| `Post-Quantum Security & ECH`              |    ✅      [^12]    |     ❌     |       ❌       | ❌             |
-| `HTTP Trailers`                            |         ✅          |     ❌     |       ❌       | ❌             |
-| `Early Responses`                          |         ✅          |     ❌     |       ❌       | ❌             |
-| `WebSocket over HTTP/1`                    |         ✅          |  ❌[^14]   |    ❌[^14]     | ✅             |
-| `WebSocket over HTTP/2 and HTTP/3`         |       ✅[^13]       |     ❌     |       ❌       | ❌             |
-| `Automatic Ping for HTTP/2+`               |         ✅          |    N/A    |       ❌       | N/A           |
-| `Automatic Connection Upgrade / Downgrade` |         ✅          |    N/A    |       ❌       | N/A           |
-| `Server Side Event (SSE)`                  |         ✅          |     ❌     |       ❌       | ❌             |
-| `WASM / Pyodide`                           |         ✅          |     ✅     |       ❌       | ❌             |
+| Feature                                    |   niquests   | requests  |     httpx     | aiohttp       |
+|--------------------------------------------|:------------:|:---------:|:-------------:|---------------|
+| `HTTP/1.1`                                 |      ✅       |     ✅     |       ✅       | ✅             |
+| `HTTP/2`                                   |      ✅       |     ❌     |     ✅[^7]     | ❌             |
+| `HTTP/3 over QUIC`                         |      ✅       |     ❌     |       ❌       | ❌             |
+| `Synchronous`                              |      ✅       |     ✅     |       ✅       | _N/A_[^1]     |
+| `Asynchronous`                             |      ✅       |     ❌     |       ✅       | ✅             |
+| `Thread Safe`                              |      ✅       |     ✅     |     ❌[^5]     | _N/A_[^1]     |
+| `Task Safe`                                |      ✅       | _N/A_[^2] |       ✅       | ✅             |
+| `OS Trust Store`                           |      ✅       |     ❌     |       ❌       | ❌             |
+| `Multiplexing`                             |      ✅       |     ❌     | _Limited_[^3] | ❌             |
+| `DNSSEC`                                   |    ✅[^11]    |     ❌     |       ❌       | ❌             |
+| `Customizable DNS Resolution`              |      ✅       |     ❌     |       ❌       | ✅             |
+| `DNS over HTTPS`                           |      ✅       |     ❌     |       ❌       | ❌             |
+| `DNS over QUIC`                            |      ✅       |     ❌     |       ❌       | ❌             |
+| `DNS over TLS`                             |      ✅       |     ❌     |       ❌       | ❌             |
+| `Multiple DNS Resolver`                    |      ✅       |     ❌     |       ❌       | ❌             |
+| `Network Fine Tuning & Inspect`            |      ✅       |     ❌     | _Limited_[^6] | _Limited_[^6] |
+| `Certificate Revocation Protection`        |      ✅       |     ❌     |       ❌       | ❌             |
+| `Session Persistence`                      |      ✅       |     ✅     |       ✅       | ✅             |
+| `In-memory Certificate CA & mTLS`          |      ✅       |     ❌     | _Limited_[^4] | _Limited_[^4] |
+| `SOCKS 4/5 Proxies`                        |      ✅       |     ✅     |       ✅       | ❌             |
+| `HTTP/HTTPS Proxies`                       |      ✅       |     ✅     |       ✅       | ✅             |
+| `TLS-in-TLS Support`                       |      ✅       |     ✅     |       ✅       | ✅             |
+| `Direct HTTP/3 Negotiation`                |    ✅[^9]     |  N/A[^8]  |    N/A[^8]    | N/A[^8]       |
+| `Happy Eyeballs`                           |      ✅       |     ❌     |       ❌       | ✅             |
+| `Package / SLSA Signed`                    |      ✅       |     ❌     |       ❌       | ✅             |
+| `HTTP/2 with prior knowledge (h2c)`        |      ✅       |     ❌     |       ✅       | ❌             |
+| `Post-Quantum Security & ECH`              | ✅      [^12] |     ❌     |       ❌       | ❌             |
+| `HTTP Trailers`                            |      ✅       |     ❌     |       ❌       | ❌             |
+| `Early Responses`                          |      ✅       |     ❌     |       ❌       | ❌             |
+| `WebSocket over HTTP/1`                    |      ✅       |  ❌[^14]   |    ❌[^14]     | ✅             |
+| `WebSocket over HTTP/2 and HTTP/3`         |    ✅[^13]    |     ❌     |       ❌       | ❌             |
+| `Automatic Ping for HTTP/2+`               |      ✅       |    N/A    |       ❌       | N/A           |
+| `Automatic Connection Upgrade / Downgrade` |      ✅       |    N/A    |       ❌       | N/A           |
+| `Server Side Event (SSE)`                  |      ✅       |     ❌     |       ❌       | ❌             |
+| `WASM / Pyodide`                           |      ✅       |     ✅     |       ❌       | ❌             |
+| `Swappable TLS Backend`                    |      ✅       |     ❌     |       ❌       | ❌             |
+| `Browser TLS Impersonation`                |    ✅[^15]    |     ❌     |       ❌       | ❌             |
 </details>
 
 <details>
@@ -162,8 +164,10 @@ Niquests is ready for the demands of building scalable, robust and reliable HTTP
 - Familiar `dict`–like Cookies
 - Network settings fine-tuning
 - HTTP/2 with prior knowledge
+- Browser TLS Impersonator
 - Object-oriented headers
 - Multi-part File Uploads
+- Swappable TLS Backend
 - Post-Quantum Security
 - Chunked HTTP Requests
 - Fully type-annotated!
@@ -224,3 +228,4 @@ Niquests is a highly improved HTTP client that is based (forked) on Requests. Th
 [^12]: depends on your Python runtime. ECH and PQ support through HTTP/3 over QUIC requires `qh3` installed. HTTP/1, and HTTP/2 can benefit from PQ and ECH, provided the `rtls` extra is installed. ECH requires you to use a custom resolver (e.g. DNS-over-HTTPS).
 [^13]: most servers out there are not ready for this feature, but Niquests is already compliant and future-proof! [Caddy](https://github.com/caddyserver/caddy/releases/tag/v2.9.0) server and [HAProxy](https://github.com/haproxy/haproxy) support this!
 [^14]: they don't offer any built-in to speak with a WebSocket server.
+[^15]: requires you to install Niquests with the `utls` extra. Everything else is automatic!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_theme_options = {
     "announcement": """
         <a style=\"text-decoration: none; color: white;\"
            href=\"https://github.com/jawah/Niquests\">
-            ⭐ Mark your support for Niquests initiative to bring an excellent, fair and free HTTP experience!
+            ⭐ Niquests 3.19 is out! Browser TLS impersonation is supported.
         </a>
         <iframe src="https://ghbtns.com/github-btn.html?user=jawah&repo=niquests&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
         """,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ html_theme_options = {
     },
     "announcement": """
         <a style=\"text-decoration: none; color: white;\"
-           href=\"https://github.com/jawah/Niquests\">
+           href=\"https://github.com/jawah/niquests/releases\">
             ⭐ Niquests 3.19 is out! Browser TLS impersonation is supported.
         </a>
         <iframe src="https://ghbtns.com/github-btn.html?user=jawah&repo=niquests&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -70,6 +70,23 @@ is done by providing data to the properties on a Session object:
         # both 'x-test' and 'x-test2' are sent
         await s.get('https://httpbin.org/headers', headers={'x-test2': 'true'})
 
+.. versionadded:: 3.19
+
+    You may also pass those defaults directly to the constructor, the same way as ``headers``::
+
+        s = niquests.Session(
+            params={'page': '1'},
+            headers={'x-test': 'true'},
+            cookies={'from-my': 'browser'},
+            auth=('user', 'pass'),
+            proxies={'https': 'http://localhost:3128'},
+            verify=True,
+        )
+
+    A native ``http.cookiejar.CookieJar`` (or a plain mapping) given to ``cookies`` is silently
+    converted to a :class:`~niquests.cookies.RequestsCookieJar`, so ``s.cookies`` always exposes the convenient mapping
+    interface (e.g. ``s.cookies.set(...)``).
+
 
 Any dictionaries that you pass to a request method will be merged with the
 session-level values that are set. The method-level parameters override session
@@ -140,7 +157,7 @@ exited, even if unhandled exceptions occurred.
 All values that are contained within a session are directly available to you.
 See the :ref:`Session API Docs <sessionapi>` to learn more.
 
-The ``Session`` class takes several (optional) named arguments for your convenience.
+The :class:`~niquests.Session` class takes several (optional) named arguments for your convenience.
 
 - `resolver`
   Specify a DNS resolver that should be used within this Session.
@@ -152,7 +169,7 @@ The ``Session`` class takes several (optional) named arguments for your convenie
   Specify a `MutableMapping` that can memorize Alt-Svc capabilities (when a server is HTTP/3 compatible).
 
 - `retries`
-  Determine the retry strategy across the ``Session`` lifetime. See :class:`~niquests.RetryConfiguration`.
+  Determine the retry strategy across the :class:`~niquests.Session` lifetime. See :class:`~niquests.RetryConfiguration`.
 
 - `multiplexed`
   Enable or disable concurrent requests when the remote host supports HTTP/2 onward.
@@ -200,7 +217,7 @@ The ``Session`` class takes several (optional) named arguments for your convenie
   Default authentication tuple or object to attach to every request emitted.
 
 - `hooks`
-  Specify default hooks to be applied to all requests made with this session. Can be a dictionary of hook names to callables, or a :class:`~niquests.hooks.LifeCycleHook` instance (or :class:`~niquests.hooks.AsyncLifeCycleHook` for ``AsyncSession``).
+  Specify default hooks to be applied to all requests made with this session. Can be a dictionary of hook names to callables, or a :class:`~niquests.hooks.LifeCycleHook` instance (or :class:`~niquests.hooks.AsyncLifeCycleHook` for :class:`~niquests.AsyncSession`).
 
 - `revocation_configuration`
   How should the session do the certificate revocation check. Set it to ``None`` to disable this additional security measure.
@@ -234,15 +251,44 @@ Setup it like follow:
         async with niquests.AsyncSession(base_url="https://httpbin.org") as s:
             await s.get('/headers')  # internally will become "https://httpbin.org/headers"
 
+Overriding the Scheme per Request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note:: Available in version 3.19+
+
+When a ``base_url`` is set, every request reuses its scheme. Sometimes you need to reach
+the same host with a different scheme (e.g. an SSE or WebSocket endpoint) without retyping
+the full URL. Pass ``override_scheme`` to any request method to swap the scheme of the final
+(``base_url``-merged) URL, just before the adapter is picked.
+
+It is only honored when a ``base_url`` is configured; otherwise you already control the full
+URL (and its scheme), so it is ignored.
+
+.. tab:: 🔂 Sync
+
+    .. code:: python
+
+        with niquests.Session(base_url="https://httpbingo.org") as s:
+            # internally targets "sse://httpbin.org/events"
+            s.get('/sse', override_scheme="sse")
+
+.. tab:: 🔀 Async
+
+    .. code:: python
+
+        async with niquests.AsyncSession(base_url="https://httpbingo.org") as s:
+            # internally targets "sse://httpbin.org/events"
+            await s.get('/sse', override_scheme="sse")
+
 Request and Response Objects
 ----------------------------
 
 Whenever a call is made to ``niquests.get()`` and friends, you are doing two
-major things. First, you are constructing a ``Request`` object which will be
-sent off to a server to request or query some resource. Second, a ``Response``
+major things. First, you are constructing a :class:`~niquests.Request` object which will be
+sent off to a server to request or query some resource. Second, a :class:`~niquests.Response`
 object is generated once Niquests gets a response back from the server.
-The ``Response`` object contains all of the information returned by the server and
-also contains the ``Request`` object you created originally. Here is a simple
+The :class:`~niquests.Response` object contains all of the information returned by the server and
+also contains the :class:`~niquests.Request` object you created originally. Here is a simple
 request to get some very important information from Wikipedia's servers::
 
     >>> r = niquests.get('https://en.wikipedia.org/wiki/Monty_Python')
@@ -273,7 +319,7 @@ Prepared Requests
 
 Whenever you receive a :class:`Response <niquests.Response>` object
 from an API call or a Session call, the ``request`` attribute is actually the
-``PreparedRequest`` that was used. In some cases you may wish to do some extra
+:class:`~niquests.PreparedRequest` that was used. In some cases you may wish to do some extra
 work to the body or headers (or anything else really) before sending a
 request. The simple recipe for this is the following:
 
@@ -331,8 +377,8 @@ request. The simple recipe for this is the following:
 
         print(resp.status_code)
 
-Since you are not doing anything special with the ``Request`` object, you
-prepare it immediately and modify the ``PreparedRequest`` object. You then
+Since you are not doing anything special with the :class:`~niquests.Request` object, you
+prepare it immediately and modify the :class:`~niquests.PreparedRequest` object. You then
 send that with the other parameters you would have sent to ``niquests.*`` or
 ``Session.*``.
 
@@ -612,9 +658,10 @@ connection!
 
 Note that connections are only released back to the pool for reuse once all body
 data has been read; be sure to either set ``stream`` to ``False`` or read the
-``content`` property of the ``Response`` object.
+``content`` property of the :class:`~niquests.Response` object.
 
-.. note:: Available since Niquests v3.10 and before this only HTTP/1.1 were kept alive properly.
+.. versionadded:: 3.10
+   Before this only HTTP/1.1 were kept alive properly.
 
 Niquests can automatically make sure that your HTTP connection is kept alive
 no matter the used protocol using a discrete scheduled task for each host.
@@ -733,7 +780,7 @@ case you can iterate chunk-by-chunk by calling ``iter_content`` with a ``chunk_s
 parameter of ``None``. If you want to set a maximum size of the chunk,
 you can set a ``chunk_size`` parameter to any integer.
 
-.. note:: Since Niquests v3.7.1+ we support having async iterable passed down to ``data=...`` via your ``AsyncSession``.
+.. note:: Since Niquests v3.7.1+ we support having async iterable passed down to ``data=...`` via your :class:`~niquests.AsyncSession`.
 
 .. _multipart:
 
@@ -825,7 +872,7 @@ You can add multiple hooks to a single request.  Let's call two hooks at once::
     >>> r.hook_called
     True
 
-You can also add hooks to a ``Session`` instance.  Any hooks you add will then
+You can also add hooks to a :class:`~niquests.Session` instance.  Any hooks you add will then
 be called on every request made to the session.  For example::
 
    >>> s = niquests.Session()
@@ -834,14 +881,14 @@ be called on every request made to the session.  For example::
     https://httpbin.org/
     <Response HTTP/2 [200]>
 
-A ``Session`` can have multiple hooks, which will be called in the order
+A :class:`~niquests.Session` can have multiple hooks, which will be called in the order
 they are added.
 
 You can find a example of how to retrieve the connection information just before the request is sent::
 
     >>> r = niquests.get("https://1.1.1.1", hooks={"pre_send": [lambda r: print(r.conn_info)]}
 
-Here, ``r`` is the ``PreparedRequest`` and ``conn_info`` contains a ``ConnectionInfo``.
+Here, ``r`` is the :class:`~niquests.PreparedRequest` and ``conn_info`` contains a ``ConnectionInfo``.
 You can explore the following data in it.
 
 - **certificate_der**: The peer certificate in DER format (binary)
@@ -886,7 +933,7 @@ In addition to dictionary-based hooks, Niquests supports class-based hooks via :
 Single Middleware
 ~~~~~~~~~~~~~~~~~
 
-You can define a custom middleware by subclassing ``AsyncLifeCycleHook`` (or ``LifeCycleHook`` for synchronous contexts) and overriding the specific event methods you need.
+You can define a custom middleware by subclassing :class:`~niquests.hooks.AsyncLifeCycleHook` (or :class:`~niquests.hooks.LifeCycleHook` for synchronous contexts) and overriding the specific event methods you need.
 
 .. code-block:: python
 
@@ -942,7 +989,7 @@ Middleware classes can be combined using the ``+`` operator. This allows you to 
         asyncio.run(main())
 
 
-.. danger:: In synchronous multi-threaded mode, using ``LifeCycleHook`` must be safe to use, you are responsible to ensure safety via proper locking if you intend to share properties/states between threads.
+.. danger:: In synchronous multi-threaded mode, using :class:`~niquests.hooks.LifeCycleHook` must be safe to use, you are responsible to ensure safety via proper locking if you intend to share properties/states between threads.
 
 Rate Limiting
 ~~~~~~~~~~~~~
@@ -1068,7 +1115,7 @@ Track upload progress
 ---------------------
 
 You may use the ``on_upload`` hook to track the upload progress of a request.
-The callable will receive the ``PreparedRequest`` that will contain a property named ``upload_progress``.
+The callable will receive the :class:`~niquests.PreparedRequest` that will contain a property named ``upload_progress``.
 
 .. note:: ``upload_progress`` is a ``TransferProgress`` instance.
 
@@ -1395,7 +1442,7 @@ manually set the :attr:`Response.encoding <niquests.Response.encoding>`
 property, or use the raw :attr:`Response.content <niquests.Response.content>`.
 
 You should keep in mind that if Niquests fail to choose a suitable encoding,
-the ``text`` method from ``Response`` will return ``None``. This is the default
+the ``text`` method from :class:`~niquests.Response` will return ``None``. This is the default
 since the version 3.
 We choose to return None in those cases because of numerous things, like for example:
 
@@ -1739,8 +1786,8 @@ In HTTP/2 onward, non-consumed response (body, aka. stream=True) will no longer 
 But if you leverage a full multiplexed connection, Niquests no longer block your synchronous
 loop. You are free of the IO blocking per request.
 
-You may also use the ``AsyncSession`` that provide you with the same methods as the regular
-``Session`` but with asyncio support.
+You may also use the :class:`~niquests.AsyncSession` that provide you with the same methods as the regular
+:class:`~niquests.Session` but with asyncio support.
 
 Header Ordering
 ---------------
@@ -1833,7 +1880,7 @@ a plain ``http`` proxy. This is meant for people who want privacy.
 This feature may not be available if the ``qh3`` package is missing from your environment.
 Verify the availability by running ``python -m niquests.help``.
 
-.. note:: Access property ``ocsp_verified`` in both ``PreparedRequest``, and ``Response`` to have information about this post handshake verification.
+.. note:: Access property ``ocsp_verified`` in both :class:`~niquests.PreparedRequest`, and :class:`~niquests.Response` to have information about this post handshake verification.
 
 .. warning:: You may be interested in caching and restoring the OCSP/CRL validator state in between runs for performance concerns. To achieve that you are invited to pickle and restore your ``niquests.Session`` object.
 
@@ -1902,7 +1949,7 @@ Disable HTTP/1.1, HTTP/2, and/or HTTP/3
 ---------------------------------------
 
 You can at your own discretion disable a protocol by passing ``disable_http2=True`` or
-``disable_http3=True`` within your ``Session`` constructor.
+``disable_http3=True`` within your :class:`~niquests.Session` constructor.
 
 Having a session without HTTP/2 enabled should be done that way::
 
@@ -1959,7 +2006,7 @@ Disable either IPv4 or IPv6
 ---------------------------
 
 You may be interested in controlling what kind of address you would accept connecting to.
-Since Niquests 3.4+, you can configure that aspect per ``Session`` instance.
+Since Niquests 3.4+, you can configure that aspect per :class:`~niquests.Session` instance.
 
 Having a session without IPv6 enabled should be done that way::
 
@@ -1973,7 +2020,7 @@ Setting the source network adapter
 ----------------------------------
 
 In a complex scenario, you could face the following: "I have multiple network adapters, some can access this and other that.."
-Since Niquests 3.4+, you can configure that aspect per ``Session`` instance.
+Since Niquests 3.4+, you can configure that aspect per :class:`~niquests.Session` instance.
 
 Having a session that explicitly bind to "10.10.4.1" on port 4444 should be done that way::
 
@@ -2019,7 +2066,7 @@ attributes is listed on the Hook bottom section.
 Verify Certificate Fingerprint
 ------------------------------
 
-.. note:: Available since Niquests 3.5.4
+.. versionadded:: 3.5.4
 
 An alternative to the certificate verification can be asserting its fingerprint. We (absolutely) do
 not recommend using it unless you are left with no other alternative.
@@ -2034,7 +2081,7 @@ Here is a simple example::
 .. warning:: Supported fingerprinting algorithms are sha256, and sha1. The prefix is mandatory.
 
 TLS Fingerprint (like JA3/JA4)
---------------------------
+------------------------------
 
 .. versionadded:: 3.19.0
 
@@ -2051,7 +2098,7 @@ To know which backend is effective, run::
 
 If you see the TLS backend being "BoringSSL (OpenSSL 1.1.1 compatible)" then you're in!
 
-.. note:: If you are getting blocked, come and get in touch with us through our Github issues. We'll help unblock the situation.
+.. note:: If you are getting blocked, come and get in touch with us through our Github issues. We'll help unblock the situation. We usually keep updating ``utls`` regularly to ensure we are up-to-date with latest browsers.
 .. warning:: Being able to unblock access via a proper TLS fingerprint does not prevent you from being IP blacklisted. Providers are smart, they know some services can't exceed 1 RPS. You'll need proxies to extend RPS targets.
 
 Tracking the real download speed
@@ -2063,7 +2110,7 @@ remote server applying a "transfer-encoding" or also know as compressing (zstd, 
 Niquests automatically decompress response bodies, so doing a call to ``iter_content`` is not going to yield
 the size actually extracted from the socket but rather from the decompressor algorithm.
 
-To remediate this issue we've implemented a new property into your ``Response`` object. Named ``download_progress``
+To remediate this issue we've implemented a new property into your :class:`~niquests.Response` object. Named ``download_progress``
 that is a ``TransferProgress`` instance.
 
 .. warning:: This feature is enabled when ``stream=True``.
@@ -2082,7 +2129,7 @@ Here is a basic example of how you would proceed::
 HTTP Trailers
 -------------
 
-.. note:: Available since Niquests 3.8+
+.. versionadded:: 3.8
 
 HTTP response may contain one or several trailer headers. Those special headers are received
 after the reception of the body. Before this, those headers were unreachable and dropped silently.
@@ -2133,7 +2180,7 @@ Revocation Configuration
 When Niquests acquire a new HTTPS connection, it defend you against revoked TLS certificate the best it can.
 Sometimes, the default behavior does not suit your environment. (e.g. corporate environment with very particular restrictions)
 
-You can alter the configuration by passing an extra parameter to your ``Session`` or ``AsyncSession`` constructor.
+You can alter the configuration by passing an extra parameter to your :class:`~niquests.Session` or :class:`~niquests.AsyncSession` constructor.
 
 .. code-block:: python
 
@@ -2175,7 +2222,7 @@ Inspecting Pooling State or Connections
 
 .. versionadded:: 3.16.0
 
-In tough situation, you may want to be able to see what's really inside of ``Session`` or ``AsyncSession``
+In tough situation, you may want to be able to see what's really inside of :class:`~niquests.Session` or :class:`~niquests.AsyncSession`
 to answer the typical questions:
 
 - How many connection do I have open?

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -2033,18 +2033,26 @@ Here is a simple example::
 
 .. warning:: Supported fingerprinting algorithms are sha256, and sha1. The prefix is mandatory.
 
-TLS Fingerprint (like JA3)
+TLS Fingerprint (like JA3/JA4)
 --------------------------
 
-Some of you seems to be interested in that topic, at least according to the statistics presented to me.
-Niquests is dedicated to providing a software that present a unique and close enough signature (against modern browser)
-that you should be protected against TLS censorship / blocking technics.
+.. versionadded:: 3.19.0
 
-We are actively working toward a way to permanently improving this.
-To help us fighting toward the greater good, feel free to sponsor us and/or speaking out loud about your
-experiences, whether about a specific country practices or global ISP/Cloud provider ones.
+If you want to be able to be seen as a browser like Google Chrome to avoid being blocked from certain services,
+Niquests support swappable TLS backend, and in those backends we support BoringSSL via ``utls``.
 
-.. note:: If you are getting blocked, come and get in touch with us through our Github issues.
+All that is needed for you to "impersonate" a modern browser is to install Niquests with::
+
+    pip install niquests[utls]
+
+To know which backend is effective, run::
+
+    python -m niquests.help
+
+If you see the TLS backend being "BoringSSL (OpenSSL 1.1.1 compatible)" then you're in!
+
+.. note:: If you are getting blocked, come and get in touch with us through our Github issues. We'll help unblock the situation.
+.. warning:: Being able to unblock access via a proper TLS fingerprint does not prevent you from being IP blacklisted. Providers are smart, they know some services can't exceed 1 RPS. You'll need proxies to extend RPS targets.
 
 Tracking the real download speed
 --------------------------------

--- a/docs/user/authentication.rst
+++ b/docs/user/authentication.rst
@@ -34,7 +34,7 @@ for using it::
     <Response HTTP/2 [200]>
 
 Providing the credentials in a tuple like this is exactly the same as the
-``HTTPBasicAuth`` example above.
+:class:`~niquests.auth.HTTPBasicAuth` example above.
 
 For DNS
 ~~~~~~~

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -86,6 +86,12 @@ Immediately swap your OpenSSL/LibreSSL default for a state-of-the-art, and memor
 
     $ python -m pip install niquests[rtls]
 
+- **utls**
+
+Immediately swap your OpenSSL/LibreSSL default for a known BoringSSL backend, used by major player like Google Chrome::
+
+    $ python -m pip install niquests[utls]
+
 - **Brotli**, **Zstandard** (zstd) and **orjson**
 
 Niquests can run significantly faster when your environment is capable of decompressing Brotli, and Zstd.
@@ -123,6 +129,8 @@ If by any chance you wanted to get the full list of (extra) features, you may in
     $ python -m pip install niquests[full]
 
 Instead of joining the long list of extras like ``zstd,socks,ws`` for example.
+
+.. note:: **full** does not include ``utls``.
 
 Get the Source Code
 -------------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -669,10 +669,30 @@ also be passed in to requests:
     >>> jar.set('tasty_cookie', 'yum', domain='httpbin.org', path='/cookies')
     >>> jar.set('gross_cookie', 'blech', domain='httpbin.org', path='/elsewhere')
     >>> url = 'https://httpbin.org/cookies'
-    >>> r = niquests.get(url, cookies=jar)
-    >>> r.text
-    '{"cookies": {"tasty_cookie": "yum"}}'
-   </pre>
+     >>> r = niquests.get(url, cookies=jar)
+     >>> r.text
+     '{"cookies": {"tasty_cookie": "yum"}}'
+    </pre>
+
+.. note::
+
+    ``Response.cookies``, ``Session.cookies`` and ``AsyncSession.cookies`` are always typed as
+    :class:`~niquests.cookies.RequestsCookieJar`. This means you can use them directly as a mapping
+    (e.g. ``session.cookies.set(...)`` or ``response.cookies['name']``) without first asserting or
+    casting the type, which static type checkers like mypy used to require.
+
+    This is **not** a runtime breaking change. Any ``http.cookiejar.CookieJar`` (or plain mapping)
+    you *pass in* is still accepted: a plain ``CookieJar`` is silently coerced to a
+    :class:`~niquests.cookies.RequestsCookieJar`, while a custom subclass (such as ``http.cookiejar.MozillaCookieJar`` and
+    other file-backed jars) is left untouched at the request level so it keeps its behavior.
+
+    The only trade-off is that *assigning* a non-:class:`~niquests.cookies.RequestsCookieJar` jar directly to the attribute,
+    for instance::
+
+        session.cookies = MozillaCookieJar("cookies.txt")  # type: ignore[assignment]
+
+    will now be flagged by type checkers. The assignment keeps working at runtime; add a
+    ``# type: ignore[assignment]`` (or a ``typing.cast``) if you rely on that pattern.
 
 Redirection and History
 -----------------------
@@ -761,7 +781,7 @@ this parameter in nearly all requests. By default GET, HEAD, OPTIONS ships with 
 
 .. tip::
 
-    Set ``happy_eyeballs=True`` when constructing your ``Session`` to try all endpoints simultaneously.
+    Set ``happy_eyeballs=True`` when constructing your :class:`~niquests.Session` to try all endpoints simultaneously.
     This will help you circumvent most of the connectivity issues.
 
 .. warning::
@@ -830,15 +850,15 @@ Starting from Niquests 3.2 you can issue concurrent requests without having mult
 It can leverage multiplexing when your remote peer support either HTTP/2, or HTTP/3.
 
 The only thing you will ever have to do to get started is to specify ``multiplexed=True`` from
-within your ``Session`` constructor.
+within your :class:`~niquests.Session` constructor.
 
-Any ``Response`` returned by get, post, put, etc... will be a lazy instance of ``Response``.
+Any :class:`~niquests.Response` returned by get, post, put, etc... will be a lazy instance of :class:`~niquests.Response`.
 
 .. note::
 
    An important note about using ``Session(multiplexed=True)`` is that, in order to be efficient
    and actually leverage its perks, you will have to issue multiple concurrent request before
-   actually trying to access any ``Response`` methods or attributes.
+   actually trying to access any :class:`~niquests.Response` methods or attributes.
 
 Modern browsers like Firefox, and Chrome utilize something really like ``multiplexed=True`` mode!
 It's a bit like if we have a controlled concurrent environment.
@@ -929,7 +949,7 @@ The possible algorithms are actually nearly limitless, and you may arrange/write
 Session Gather
 --------------
 
-The ``Session`` instance expose a method called ``gather(*responses, max_fetch = None)``, you may call it to
+The :class:`~niquests.Session` instance expose a method called ``gather(*responses, max_fetch = None)``, you may call it to
 improve the efficiency of resolving your _lazy_ responses.
 
 Here are the possible outcome of invocation:
@@ -960,7 +980,7 @@ Async session
 -------------
 
 You may have a program that require ``awaitable`` HTTP request. You are in luck as **Niquests** ships with
-an implementation of ``Session`` that support **async**.
+an implementation of :class:`~niquests.Session` that support **async**.
 
 All known methods remain the same at the sole difference that it return a coroutine.
 
@@ -1028,7 +1048,7 @@ Look at this basic sample::
         asyncio.run(main())
 
 
-.. warning:: Combining AsyncSession with ``multiplexed=True`` and passing ``stream=True`` produces ``AsyncResponse``, make sure to call ``await session.gather()`` before trying to access directly the lazy instance of response.
+.. warning:: Combining AsyncSession with ``multiplexed=True`` and passing ``stream=True`` produces :class:`~niquests.AsyncResponse`, make sure to call ``await session.gather()`` before trying to access directly the lazy instance of response.
 
 AsyncResponse for streams
 -------------------------
@@ -1081,7 +1101,7 @@ Or simply by doing::
 
         asyncio.run(main())
 
-When you specify ``stream=True`` within a ``AsyncSession``, the returned object will be of type ``AsyncResponse``.
+When you specify ``stream=True`` within a :class:`~niquests.AsyncSession`, the returned object will be of type :class:`~niquests.AsyncResponse`.
 So that the following methods and properties will be coroutines (aka. awaitable):
 
 - iter_content(...)
@@ -1126,7 +1146,7 @@ Here is a basic example of how you would do it::
 
         asyncio.run(main())
 
-.. warning:: Accessing (non awaitable attribute or method) of a lazy ``AsyncResponse`` without a call to ``s.gather()`` will raise an error.
+.. warning:: Accessing (non awaitable attribute or method) of a lazy :class:`~niquests.AsyncResponse` without a call to ``s.gather()`` will raise an error.
 
 Scale your Session / Pool
 -------------------------
@@ -1198,7 +1218,7 @@ DNSSEC in additions to specifics security perks on chosen protocol.
 Specify your own resolver
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to specify a resolver, you have to use a ``Session``. Each ``Session`` can have a different resolver.
+In order to specify a resolver, you have to use a :class:`~niquests.Session`. Each :class:`~niquests.Session` can have a different resolver.
 Here is a basic example that leverage Google public DNS over HTTPS.
 
 .. tab:: 🔂 Sync
@@ -1328,7 +1348,7 @@ This will prevent any DNS resolution that last longer to a second.
 Happy Eyeballs
 --------------
 
-.. note:: Available since version 3.5.5+
+.. versionadded:: 3.5.5
 
 Thanks to the underlying library (urllib3.future) we are able to serve the Happy Eyeballs feature, one toggle away.
 
@@ -1369,7 +1389,8 @@ OCSP requests (certificate revocation checks) will follow given ``happy_eyeballs
 WebSockets
 ----------
 
-.. note:: Available since version 3.9+ and requires to install an extra. ``pip install niquests[ws]``.
+.. versionadded:: 3.9
+   Requires to install an extra. ``pip install niquests[ws]``.
 
 It is undeniable that WebSockets are a vital part of the web ecosystem along with HTTP. We noticed that
 most users met frictions when trying to deal with a WebSocket server for the first time, that is why
@@ -1621,7 +1642,7 @@ We will use a Thread for the reads and the main thread for write operations.
 Server Sent Event (SSE)
 -----------------------
 
-.. note:: Available since version 3.11.2+
+.. versionadded:: 3.11.2
 
 Server sent event or widely known with its acronym SSE is a extremely popular method to stream continuously event
 from the server to the client in real time.
@@ -2106,7 +2127,7 @@ Running in the Browser (Pyodide)
 .. versionadded:: 3.18.0
 
 Niquests runs natively in `Pyodide <https://pyodide.org>`_ with zero configuration changes.
-Your existing code: HTTP requests, WebSocket, and SSE works identically using ``Session``, or ``AsyncSession``,
+Your existing code: HTTP requests, WebSocket, and SSE works identically using :class:`~niquests.Session`, or :class:`~niquests.AsyncSession`,
 and ``resp.extension``. The adapter is selected automatically when Pyodide is detected.
 
 .. warning:: The sync interfaces requires a JSPI capable browser or Node interpreter. Modern build of Firefox, Chrome and Node support it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ brotli = [
 rtls = [
     "urllib3.future[rtls]",
 ]
+utls = [
+    "urllib3.future[utls]",
+]
 full = [
     "orjson>=3,<4",
     "urllib3.future[zstd,brotli,ws,socks,rtls]",

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.18.8"
+__version__ = "3.19.0"
 
-__build__: int = 0x031808
+__build__: int = 0x031900
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -294,6 +294,7 @@ class HTTPAdapter(BaseAdapter):
         "_keepalive_delay",
         "_keepalive_idle_window",
         "_revocation_configuration",
+        "_allow_incoming_cookies",
     ]
 
     def __init__(
@@ -316,6 +317,7 @@ class HTTPAdapter(BaseAdapter):
         keepalive_delay: float | int | None = 600.0,
         keepalive_idle_window: float | int | None = 60.0,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
+        allow_incoming_cookies: bool = True,
     ):
         if isinstance(max_retries, bool):
             self.max_retries: RetryType = False
@@ -360,6 +362,8 @@ class HTTPAdapter(BaseAdapter):
         self._crl_cache: typing.Any | None = None
 
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
+
+        self._allow_incoming_cookies: bool = allow_incoming_cookies
 
         disabled_svn = set()
 
@@ -982,6 +986,7 @@ class HTTPAdapter(BaseAdapter):
 
         hooks: HookType = response._promise.get_parameter("niquests_hooks")  # type: ignore[assignment]
         session_cookies: CookieJar = response._promise.get_parameter("niquests_cookies")  # type: ignore[assignment]
+        allow_incoming_cookies: bool = self._allow_incoming_cookies
         allow_redirects: bool = response._promise.get_parameter(  # type: ignore[assignment]
             "niquests_allow_redirect"
         )
@@ -1018,7 +1023,8 @@ class HTTPAdapter(BaseAdapter):
 
         # Add new cookies from the server.
         extract_cookies_to_jar(response.cookies, req, low_resp)
-        extract_cookies_to_jar(session_cookies, req, low_resp)
+        if allow_incoming_cookies:
+            extract_cookies_to_jar(session_cookies, req, low_resp)
 
         promise_ctx_backup = {
             k: v for k, v in response_promise._parameters.items() if k.startswith("niquests_") and k != "niquests_response"
@@ -1161,7 +1167,8 @@ class HTTPAdapter(BaseAdapter):
         if response.history:
             # If the hooks create history then we want those cookies too
             for sub_resp in response.history:
-                extract_cookies_to_jar(session_cookies, sub_resp.request, sub_resp.raw)
+                if allow_incoming_cookies:
+                    extract_cookies_to_jar(session_cookies, sub_resp.request, sub_resp.raw)
 
         if not stream:
             if response.extension is None:
@@ -1370,6 +1377,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         "_keepalive_delay",
         "_keepalive_idle_window",
         "_revocation_configuration",
+        "_allow_incoming_cookies",
     ]
 
     def __init__(
@@ -1392,6 +1400,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         keepalive_delay: float | int | None = 600.0,
         keepalive_idle_window: float | int | None = 60.0,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
+        allow_incoming_cookies: bool = True,
     ):
         if isinstance(max_retries, bool):
             self.max_retries: RetryType = False
@@ -1437,6 +1446,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         self._crl_cache: typing.Any | None = None
 
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
+
+        self._allow_incoming_cookies: bool = allow_incoming_cookies
 
         disabled_svn = set()
 
@@ -2066,6 +2077,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         start: float = response._promise.get_parameter("niquests_start")  # type: ignore[assignment]
         hooks: HookType = response._promise.get_parameter("niquests_hooks")  # type: ignore[assignment]
         session_cookies: CookieJar = response._promise.get_parameter("niquests_cookies")  # type: ignore[assignment]
+        allow_incoming_cookies: bool = self._allow_incoming_cookies
         allow_redirects: bool = response._promise.get_parameter(  # type: ignore[assignment]
             "niquests_allow_redirect"
         )
@@ -2102,7 +2114,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
 
         # Add new cookies from the server.
         extract_cookies_to_jar(response.cookies, req, low_resp)
-        extract_cookies_to_jar(session_cookies, req, low_resp)
+        if allow_incoming_cookies:
+            extract_cookies_to_jar(session_cookies, req, low_resp)
 
         promise_ctx_backup = {
             k: v for k, v in response_promise._parameters.items() if k.startswith("niquests_") and k != "niquests_response"
@@ -2249,7 +2262,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         if response.history:
             # If the hooks create history then we want those cookies too
             for sub_resp in response.history:
-                extract_cookies_to_jar(session_cookies, sub_resp.request, sub_resp.raw)
+                if allow_incoming_cookies:
+                    extract_cookies_to_jar(session_cookies, sub_resp.request, sub_resp.raw)
 
         if not stream:
             if response.extension is None:

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -152,6 +152,7 @@ class AsyncSession(Session):
         proxies: ProxyType | None = None,
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
+        allow_incoming_cookies: bool = True,
     ):
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -258,6 +259,11 @@ class AsyncSession(Session):
         #: native ``cookielib.CookieJar`` passed at construction time is silently coerced.
         self.cookies: RequestsCookieJar = coerce_to_requests_cookiejar(cookies, thread_free=True)
 
+        #: Toggle whether cookies sent by the remote peer (``Set-Cookie``) are extracted and merged
+        #: into this Session. When ``False``, every incoming cookie is ignored while outgoing cookies
+        #: set by the user are still emitted.
+        self.allow_incoming_cookies: bool = allow_incoming_cookies
+
         #: A simple dict that allows us to persist which server support QUIC
         #: It is simply forwarded to urllib3.future that handle the caching logic.
         #: Can be any mutable mapping.
@@ -298,6 +304,7 @@ class AsyncSession(Session):
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -317,6 +324,7 @@ class AsyncSession(Session):
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -336,6 +344,7 @@ class AsyncSession(Session):
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
         else:
@@ -393,6 +402,7 @@ class AsyncSession(Session):
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         self.mount(
@@ -412,6 +422,7 @@ class AsyncSession(Session):
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         self.mount(
@@ -431,6 +442,7 @@ class AsyncSession(Session):
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         for adapter in self.adapters.values():
@@ -653,6 +665,7 @@ class AsyncSession(Session):
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -672,6 +685,7 @@ class AsyncSession(Session):
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -691,6 +705,7 @@ class AsyncSession(Session):
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
 
@@ -753,12 +768,13 @@ class AsyncSession(Session):
         r = await async_dispatch_hook("response", hooks, r, **kwargs)  # type: ignore[arg-type]
 
         # Persist cookies
-        if r.history:
-            # If the hooks create history then we want those cookies too
-            for resp in r.history:
-                extract_cookies_to_jar(self.cookies, resp.request, resp.raw)
+        if self.allow_incoming_cookies:
+            if r.history:
+                # If the hooks create history then we want those cookies too
+                for resp in r.history:
+                    extract_cookies_to_jar(self.cookies, resp.request, resp.raw)
 
-        extract_cookies_to_jar(self.cookies, request, r.raw)
+            extract_cookies_to_jar(self.cookies, request, r.raw)
 
         # Resolve redirects if allowed.
         if allow_redirects:
@@ -909,7 +925,8 @@ class AsyncSession(Session):
             # Extract any cookies sent on the response to the cookiejar
             # in the new request. Because we've mutated our copied prepared
             # request, use the old one that we haven't yet touched.
-            extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
+            if self.allow_incoming_cookies:
+                extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
             merge_cookies(prepared_request._cookies, self.cookies)
             prepared_request.prepare_cookies(prepared_request._cookies)
 
@@ -962,7 +979,8 @@ class AsyncSession(Session):
                 if hasattr(resp, "lazy") and resp.lazy:
                     await self.gather(resp)
 
-                extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
+                if self.allow_incoming_cookies:
+                    extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 
                 # extract redirect url, if any, for the next loop
                 url = self.get_redirect_target(resp)

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -1005,6 +1005,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType | None = ...,
         cert: TLSClientCertType | None = ...,
         json: typing.Any | None = ...,
+        override_scheme: str | None = ...,
     ) -> Response: ...
 
     @typing.overload  # type: ignore[override]
@@ -1026,6 +1027,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType | None = ...,
         cert: TLSClientCertType | None = ...,
         json: typing.Any | None = ...,
+        override_scheme: str | None = ...,
     ) -> AsyncResponse: ...
 
     async def request(  # type: ignore[override]
@@ -1046,6 +1048,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
         json: typing.Any | None = None,
+        override_scheme: str | None = None,
     ) -> Response | AsyncResponse:
         if method.isupper() is False:
             method = method.upper()
@@ -1063,6 +1066,7 @@ class AsyncSession(Session):
             cookies=cookies,
             hooks=hooks,
             base_url=self.base_url,
+            override_scheme=override_scheme,
         )
 
         prep: PreparedRequest = self.prepare_request(req)

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -7,7 +7,6 @@ import typing
 import warnings
 from collections import OrderedDict
 from datetime import timedelta
-from http.cookiejar import CookieJar
 from urllib.parse import urljoin, urlparse
 
 from .status_codes import codes
@@ -25,7 +24,7 @@ from ._constant import (
 from .adapters import AsyncBaseAdapter, AsyncHTTPAdapter
 from .cookies import (
     RequestsCookieJar,
-    cookiejar_from_dict,
+    coerce_to_requests_cookiejar,
     extract_cookies_to_jar,
     merge_cookies,
 )
@@ -44,8 +43,6 @@ try:
 except ImportError:
     AsyncPyodideAdapter = None  # type: ignore[assignment,misc]
     if sys.platform == "emscripten":
-        import warnings
-
         warnings.warn(
             "unable to load native WASM adapter for AsyncSession. HTTP requests may fail in async.",
             UserWarning,
@@ -150,6 +147,11 @@ class AsyncSession(Session):
         hooks: AsyncHookType[PreparedRequest | Response | AsyncResponse] | None = None,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         app: ASGIApp | None = None,
+        params: QueryParameterType | None = None,
+        cookies: CookiesType | None = None,
+        proxies: ProxyType | None = None,
+        verify: TLSVerifyType | None = None,
+        cert: TLSClientCertType | None = None,
     ):
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -177,7 +179,7 @@ class AsyncSession(Session):
         #: Dictionary mapping protocol or protocol and host to the URL of the proxy
         #: (e.g. {'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}) to
         #: be used on each :class:`Request <Request>`.
-        self.proxies: ProxyType = {}
+        self.proxies: ProxyType = proxies if proxies is not None else {}
 
         #: Event-handling hooks.
         self.hooks: AsyncHookType[PreparedRequest | Response | AsyncResponse] = (
@@ -189,7 +191,7 @@ class AsyncSession(Session):
         #: Dictionary of querystring data to attach to each
         #: :class:`Request <Request>`. The dictionary values may be lists for
         #: representing multivalued query parameters.
-        self.params: QueryParameterType = {}
+        self.params: QueryParameterType = params if params is not None else {}
 
         #: Stream response content default.
         self.stream = False
@@ -231,11 +233,11 @@ class AsyncSession(Session):
         #: expired certificates, which will make your application vulnerable to
         #: man-in-the-middle (MitM) attacks.
         #: Only set this to `False` for testing.
-        self.verify: TLSVerifyType = True
+        self.verify: TLSVerifyType = verify if verify is not None else True
 
         #: SSL client certificate default, if String, path to ssl client
         #: cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
-        self.cert: TLSClientCertType | None = None
+        self.cert: TLSClientCertType | None = cert
 
         #: Maximum number of redirects allowed. If the request exceeds this
         #: limit, a :class:`TooManyRedirects` exception is raised.
@@ -251,10 +253,10 @@ class AsyncSession(Session):
         self.base_url: str | None = base_url
 
         #: A CookieJar containing all currently outstanding cookies set on this
-        #: session. By default it is a
-        #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`, but
-        #: may be any other ``cookielib.CookieJar`` compatible object.
-        self.cookies: RequestsCookieJar | CookieJar = cookiejar_from_dict({}, thread_free=True)
+        #: session. It is always a
+        #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`. A mapping or a
+        #: native ``cookielib.CookieJar`` passed at construction time is silently coerced.
+        self.cookies: RequestsCookieJar = coerce_to_requests_cookiejar(cookies, thread_free=True)
 
         #: A simple dict that allows us to persist which server support QUIC
         #: It is simply forwarded to urllib3.future that handle the caching logic.

--- a/src/niquests/cookies.py
+++ b/src/niquests/cookies.py
@@ -568,6 +568,26 @@ def cookiejar_from_dict(
     return cookiejar
 
 
+def coerce_to_requests_cookiejar(
+    cookies: typing.MutableMapping[str, str] | cookielib.CookieJar | None,
+    thread_free: bool = False,
+) -> RequestsCookieJar:
+    """Coerce a user provided cookies value into a ``RequestsCookieJar``."""
+    if isinstance(cookies, RequestsCookieJar):
+        return cookies
+
+    jar = RequestsCookieJar(thread_free=thread_free)
+
+    if cookies is None:
+        return jar
+
+    if isinstance(cookies, cookielib.CookieJar):
+        jar.update(cookies)
+        return jar
+
+    return cookiejar_from_dict(cookies, cookiejar=jar)  # type: ignore[return-value]
+
+
 def merge_cookies(
     cookiejar: RequestsCookieJar | cookielib.CookieJar,
     cookies: typing.Mapping[str, str] | RequestsCookieJar | CookieJar,

--- a/src/niquests/extensions/pyodide/__init__.py
+++ b/src/niquests/extensions/pyodide/__init__.py
@@ -239,7 +239,9 @@ class PyodideAdapter(BaseAdapter):
         if request.headers:
             for key, value in request.headers.items():
                 if key.lower() not in ("host", "content-length", "connection", "transfer-encoding"):
-                    headers_dict[key] = value
+                    headers_dict[key if isinstance(key, str) else key.decode("latin-1")] = (
+                        value if isinstance(value, str) else value.decode("latin-1")
+                    )
 
         # Prepare body
         body = request.body
@@ -288,7 +290,9 @@ class PyodideAdapter(BaseAdapter):
                 js_headers = js_response.headers
                 if hasattr(js_headers, "items"):
                     for key, value in js_headers.items():
-                        response_headers[key] = value
+                        response_headers[key if isinstance(key, str) else key.decode("latin-1")] = (
+                            value if isinstance(value, str) else value.decode("latin-1")
+                        )
                 elif hasattr(js_headers, "entries"):
                     for entry in js_headers.entries():
                         response_headers[entry[0]] = entry[1]
@@ -364,7 +368,9 @@ class PyodideAdapter(BaseAdapter):
         if request.headers:
             for key, value in request.headers.items():
                 if key.lower() not in ("host", "content-length", "connection"):
-                    headers_dict[key] = value
+                    headers_dict[key if isinstance(key, str) else key.decode("latin-1")] = (
+                        value if isinstance(value, str) else value.decode("latin-1")
+                    )
 
         try:
             ext = PyodideSSEExtension(http_url, headers=headers_dict)

--- a/src/niquests/extensions/pyodide/_async/__init__.py
+++ b/src/niquests/extensions/pyodide/_async/__init__.py
@@ -269,7 +269,9 @@ class AsyncPyodideAdapter(AsyncBaseAdapter):
             for key, value in request.headers.items():
                 # Skip headers that browsers don't allow to be set
                 if key.lower() not in ("host", "content-length", "connection", "transfer-encoding"):
-                    headers_dict[key] = value
+                    headers_dict[key if isinstance(key, str) else key.decode("latin-1")] = (
+                        value if isinstance(value, str) else value.decode("latin-1")
+                    )
 
         # Prepare body
         body = request.body
@@ -329,7 +331,9 @@ class AsyncPyodideAdapter(AsyncBaseAdapter):
                 js_headers = js_response.headers
                 if hasattr(js_headers, "items"):
                     for key, value in js_headers.items():
-                        response_headers[key] = value
+                        response_headers[key if isinstance(key, str) else key.decode("latin-1")] = (
+                            value if isinstance(value, str) else value.decode("latin-1")
+                        )
                 elif hasattr(js_headers, "entries"):
                     # JavaScript Headers.entries() returns an iterator
                     for entry in js_headers.entries():
@@ -417,7 +421,9 @@ class AsyncPyodideAdapter(AsyncBaseAdapter):
         if request.headers:
             for key, value in request.headers.items():
                 if key.lower() not in ("host", "content-length", "connection"):
-                    headers_dict[key] = value
+                    headers_dict[key if isinstance(key, str) else key.decode("latin-1")] = (
+                        value if isinstance(value, str) else value.decode("latin-1")
+                    )
 
         ext = AsyncPyodideSSEExtension()
 

--- a/src/niquests/extensions/sgi/__init__.py
+++ b/src/niquests/extensions/sgi/__init__.py
@@ -310,6 +310,7 @@ class WebServerGatewayInterface(BaseAdapter):
 
         if request.headers:
             for key, value in request.headers.items():
+                key = key if isinstance(key, str) else key.decode("latin-1")
                 key_upper = key.upper().replace("-", "_")
                 if key_upper == "CONTENT_TYPE":
                     environ["CONTENT_TYPE"] = value

--- a/src/niquests/extensions/sgi/_async/__init__.py
+++ b/src/niquests/extensions/sgi/_async/__init__.py
@@ -492,7 +492,13 @@ class AsyncServerGatewayInterface(AsyncBaseAdapter):
         headers: list[tuple[bytes, bytes]] = []
         if request.headers:
             for key, value in request.headers.items():
-                headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+                key = key if isinstance(key, str) else key.decode("latin-1")
+                headers.append(
+                    (
+                        key.lower().encode("latin-1"),
+                        value.encode("latin-1") if isinstance(value, str) else value,
+                    )
+                )
 
         scope: dict[str, typing.Any] = {
             "type": "http",
@@ -523,7 +529,13 @@ class AsyncServerGatewayInterface(AsyncBaseAdapter):
         headers: list[tuple[bytes, bytes]] = []
         if request.headers:
             for key, value in request.headers.items():
-                headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+                key = key if isinstance(key, str) else key.decode("latin-1")
+                headers.append(
+                    (
+                        key.lower().encode("latin-1"),
+                        value.encode("latin-1") if isinstance(value, str) else value,
+                    )
+                )
 
         scheme = "wss" if parsed.scheme == "wss" else "ws"
 

--- a/src/niquests/help.py
+++ b/src/niquests/help.py
@@ -6,12 +6,15 @@ import json
 import platform
 
 try:
-    import rtls as ssl
+    from .packages.urllib3.contrib.anytls import ssl
 except ImportError:
     try:
-        import ssl  # type: ignore[no-redef]
+        import rtls as ssl  # type: ignore[no-redef]
     except ImportError:
-        ssl = None  # type: ignore
+        try:
+            import ssl  # type: ignore[no-redef]
+        except ImportError:
+            ssl = None  # type: ignore
 
 import sys
 import warnings

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -303,7 +303,7 @@ class PreparedRequest:
         #: HTTP URL to send the request to.
         self.url: str | None = None
         #: dictionary of HTTP headers.
-        self.headers: CaseInsensitiveDict | None = None
+        self.headers: CaseInsensitiveDict[str | bytes, str | bytes] | None = None
         # The `CookieJar` used to create the Cookie header will be stored here
         # after prepare_cookies is called
         self._cookies: RequestsCookieJar | cookielib.CookieJar | None = None
@@ -956,11 +956,11 @@ class Response:
         #: Case-insensitive Dictionary of Response Headers.
         #: For example, ``headers['content-encoding']`` will return the
         #: value of a ``'Content-Encoding'`` response header.
-        self.headers: CaseInsensitiveDict = CaseInsensitiveDict()
+        self.headers: CaseInsensitiveDict[str, str] = CaseInsensitiveDict()
 
         #: Case-insensitive Dictionary of Response Trailer Headers.
         #: This can only be filled after response consumption.
-        self.trailers: CaseInsensitiveDict = CaseInsensitiveDict()
+        self.trailers: CaseInsensitiveDict[str, str] = CaseInsensitiveDict()
 
         #: File-like object representation of response (for advanced usage).
         #: Use of ``raw`` requires that ``stream=True`` be set on the request.

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -197,6 +197,7 @@ class Request:
         hooks: HookType | AsyncHookType | None = None,
         json: typing.Any | None = None,
         base_url: str | None = None,
+        override_scheme: str | None = None,
     ):
         # Default empty dicts for dict params.
         data = [] if data is None else data
@@ -219,6 +220,7 @@ class Request:
         self.auth = auth
         self.cookies = cookies
         self.base_url = base_url
+        self.override_scheme = override_scheme
 
     @property
     def oheaders(self) -> Headers:
@@ -269,6 +271,7 @@ class Request:
             cookies=self.cookies,
             hooks=self.hooks,
             base_url=self.base_url,
+            override_scheme=self.override_scheme,
         )
 
         return p
@@ -339,11 +342,12 @@ class PreparedRequest:
         hooks: HookType[Response | PreparedRequest] | None = None,
         json: typing.Any | None = None,
         base_url: str | None = None,
+        override_scheme: str | None = None,
     ) -> None:
         """Prepares the entire request with the given parameters."""
 
         self.prepare_method(method)
-        self.prepare_url(url, params, base_url=base_url)
+        self.prepare_url(url, params, base_url=base_url, override_scheme=override_scheme)
         self.prepare_headers(headers)
         self.prepare_cookies(cookies)
         self.prepare_body(data, files, json)
@@ -379,6 +383,7 @@ class PreparedRequest:
         params: QueryParameterType | None,
         *,
         base_url: str | None = None,
+        override_scheme: str | None = None,
     ) -> None:
         """Prepares the given HTTP URL."""
         assert url is not None, "Missing URL in PreparedRequest"
@@ -421,13 +426,20 @@ class PreparedRequest:
         except LocationParseError as e:
             raise InvalidURL(*e.args)
 
+        # Override the scheme of the (base_url-)merged URL. This is only meaningful when a base_url
+        # is set, otherwise the user already fully controls the URL (and its scheme). The URL is then
+        # rebuilt below from its components, so we just swap the scheme here.
+        override_applied = base_url is not None and override_scheme is not None
+        if override_applied:
+            scheme = override_scheme
+
         if not host:
             raise InvalidURL(f"Invalid URL {url!r}: No host supplied")
 
         if host.startswith(("*", ".")):
             raise InvalidURL("URL has an invalid label.")
 
-        if (not path or "%" not in path) and not auth and not params and not host.startswith("xn--"):
+        if not override_applied and (not path or "%" not in path) and not auth and not params and not host.startswith("xn--"):
             self.url = url
             return
 

--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -28,7 +28,6 @@ if typing.TYPE_CHECKING:
 
 from collections.abc import Mapping
 from http import cookiejar as cookielib
-from http.cookiejar import CookieJar
 from io import UnsupportedOperation
 from urllib.parse import urlencode, urlsplit, urlunparse
 
@@ -40,6 +39,7 @@ from .auth import BearerTokenAuth, HTTPBasicAuth
 from .cookies import (
     RequestsCookieJar,
     _copy_cookie_jar,
+    coerce_to_requests_cookiejar,
     cookiejar_from_dict,
     get_cookie_header,
 )
@@ -306,7 +306,7 @@ class PreparedRequest:
         self.headers: CaseInsensitiveDict | None = None
         # The `CookieJar` used to create the Cookie header will be stored here
         # after prepare_cookies is called
-        self._cookies: RequestsCookieJar | CookieJar | None = None
+        self._cookies: RequestsCookieJar | cookielib.CookieJar | None = None
         #: request body to send to the server.
         self.body: BodyType | AsyncBodyType | None = None
         #: dictionary of callback hooks, for internal usage.
@@ -666,7 +666,14 @@ class PreparedRequest:
         """
         assert self.headers is not None, "method prepare_cookies must be invoked after prepare_headers"
 
-        if isinstance(cookies, cookielib.CookieJar):
+        if type(cookies) is cookielib.CookieJar:
+            # A plain stdlib CookieJar carries no special behavior, so we coerce it into a
+            # RequestsCookieJar to expose the convenient mapping interface.
+            self._cookies = coerce_to_requests_cookiejar(cookies)
+        elif isinstance(cookies, cookielib.CookieJar):
+            # A RequestsCookieJar or an unknown CookieJar subclass (e.g. MozillaCookieJar or any
+            # file-backed/custom jar) is left untouched: converting it could drop its specific
+            # behavior and break the write-back of response cookies into the caller's own jar.
             self._cookies = cookies
         else:
             self._cookies = cookiejar_from_dict(cookies)
@@ -975,7 +982,7 @@ class Response:
         self.reason: str | None = None
 
         #: A CookieJar of Cookies the server sent back.
-        self.cookies: CookieJar = cookiejar_from_dict({})
+        self.cookies: RequestsCookieJar = RequestsCookieJar()
 
         #: The amount of time elapsed between sending the request
         #: and the arrival of the response (as a timedelta).

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -583,6 +583,7 @@ class Session:
             cookies=merged_cookies,
             hooks=merge_hooks(request.hooks, self.hooks),
             base_url=self.base_url,
+            override_scheme=request.override_scheme,
         )
         return p
 
@@ -604,6 +605,7 @@ class Session:
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
         json: typing.Any | None = None,
+        override_scheme: str | None = None,
     ) -> Response:
         """Constructs a :class:`Request <Request>`, prepares it and sends it.
         Returns :class:`Response <Response>` object.
@@ -645,6 +647,10 @@ class Session:
             It is also possible to put the certificates (directly) in a string or bytes.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+        :param override_scheme: (optional) Override the scheme of the final URL just before picking
+            the adapter. Only applied when a ``base_url`` is set on the Session. Useful to target a
+            different scheme (e.g. ``sse`` or ``ws``/``wss``, optionally with an implementation suffix
+            like ``sse+unix``) than the one carried by ``base_url`` without retyping the full URL.
         """
         # Kept for BC-purposes. One may use lowercase http verb.
         if method.isupper() is False:
@@ -663,6 +669,7 @@ class Session:
             cookies=cookies,
             hooks=hooks,
             base_url=self.base_url,
+            override_scheme=override_scheme,
         )
 
         prep: PreparedRequest = self.prepare_request(req)

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import timedelta
 from http import cookiejar as cookielib
-from http.cookiejar import CookieJar
 from urllib.parse import urljoin, urlparse
 
 from ._compat import HAS_LEGACY_URLLIB3, iscoroutinefunction, urllib3_ensure_type
@@ -31,6 +30,7 @@ from .adapters import BaseAdapter, HTTPAdapter
 from .auth import _basic_auth_str
 from .cookies import (
     RequestsCookieJar,
+    coerce_to_requests_cookiejar,
     cookiejar_from_dict,
     extract_cookies_to_jar,
     merge_cookies,
@@ -270,6 +270,11 @@ class Session:
         hooks: HookType[PreparedRequest | Response] | None = None,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         app: WSGIApp | ASGIApp | None = None,
+        params: QueryParameterType | None = None,
+        cookies: CookiesType | None = None,
+        proxies: ProxyType | None = None,
+        verify: TLSVerifyType | None = None,
+        cert: TLSClientCertType | None = None,
     ):
         """
         :param resolver: Specify a DNS resolver that should be used within this Session.
@@ -301,6 +306,12 @@ class Session:
         :param revocation_configuration: How should that session do the certificate revocation check. Set it as None to disable
             this additional security measure.
         :param app: A WSGI (e.g. Flask) or ASGI (e.g. FastAPI) app to be mounted automatically.
+        :param params: Default query string parameters to be merged into every request emitted.
+        :param cookies: Default cookies to attach to every request emitted. A mapping or any
+            ``http.cookiejar.CookieJar`` is accepted and silently coerced to a ``RequestsCookieJar``.
+        :param proxies: Default proxies mapping to be used on every request emitted.
+        :param verify: Default TLS verification policy to be used on every request emitted.
+        :param cert: Default TLS client certificate to be used on every request emitted.
         """
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -328,7 +339,7 @@ class Session:
         #: Dictionary mapping protocol or protocol and host to the URL of the proxy
         #: (e.g. {'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}) to
         #: be used on each :class:`Request <Request>`.
-        self.proxies: ProxyType = {}
+        self.proxies: ProxyType = proxies if proxies is not None else {}
 
         #: Event-handling hooks.
         self.hooks: HookType[PreparedRequest | Response] = (
@@ -338,7 +349,7 @@ class Session:
         #: Dictionary of querystring data to attach to each
         #: :class:`Request <Request>`. The dictionary values may be lists for
         #: representing multivalued query parameters.
-        self.params: QueryParameterType = {}
+        self.params: QueryParameterType = params if params is not None else {}
 
         #: Stream response content default.
         self.stream = False
@@ -380,11 +391,11 @@ class Session:
         #: expired certificates, which will make your application vulnerable to
         #: man-in-the-middle (MitM) attacks.
         #: Only set this to `False` for testing.
-        self.verify: TLSVerifyType = True
+        self.verify: TLSVerifyType = verify if verify is not None else True
 
         #: SSL client certificate default, if String, path to ssl client
         #: cert file (.pem). If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
-        self.cert: TLSClientCertType | None = None
+        self.cert: TLSClientCertType | None = cert
 
         #: Maximum number of redirects allowed. If the request exceeds this
         #: limit, a :class:`TooManyRedirects` exception is raised.
@@ -400,10 +411,10 @@ class Session:
         self.base_url: str | None = base_url
 
         #: A CookieJar containing all currently outstanding cookies set on this
-        #: session. By default it is a
-        #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`, but
-        #: may be any other ``cookielib.CookieJar`` compatible object.
-        self.cookies: RequestsCookieJar | CookieJar = cookiejar_from_dict({})
+        #: session. It is always a
+        #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`. A mapping or a
+        #: native ``cookielib.CookieJar`` passed at construction time is silently coerced.
+        self.cookies: RequestsCookieJar = coerce_to_requests_cookiejar(cookies)
 
         #: A simple dict that allows us to persist which server support QUIC
         #: It is simply forwarded to urllib3.future that handle the caching logic.

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -218,6 +218,7 @@ class Session:
         "headers",
         "cookies",
         "auth",
+        "allow_incoming_cookies",
         "proxies",
         "hooks",
         "params",
@@ -275,6 +276,7 @@ class Session:
         proxies: ProxyType | None = None,
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
+        allow_incoming_cookies: bool = True,
     ):
         """
         :param resolver: Specify a DNS resolver that should be used within this Session.
@@ -312,6 +314,9 @@ class Session:
         :param proxies: Default proxies mapping to be used on every request emitted.
         :param verify: Default TLS verification policy to be used on every request emitted.
         :param cert: Default TLS client certificate to be used on every request emitted.
+        :param allow_incoming_cookies: Toggle whether cookies sent by the remote peer (via ``Set-Cookie``)
+            should be extracted and merged into this Session. Set it to ``False`` to ignore every incoming
+            cookie. Outgoing cookies you set yourself are still sent. Defaults to ``True``.
         """
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -416,6 +421,11 @@ class Session:
         #: native ``cookielib.CookieJar`` passed at construction time is silently coerced.
         self.cookies: RequestsCookieJar = coerce_to_requests_cookiejar(cookies)
 
+        #: Toggle whether cookies sent by the remote peer (``Set-Cookie``) are extracted and merged
+        #: into this Session. When ``False``, every incoming cookie is ignored while outgoing cookies
+        #: set by the user are still emitted.
+        self.allow_incoming_cookies: bool = allow_incoming_cookies
+
         #: A simple dict that allows us to persist which server support QUIC
         #: It is simply forwarded to urllib3.future that handle the caching logic.
         #: Can be any mutable mapping.
@@ -455,6 +465,7 @@ class Session:
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -474,6 +485,7 @@ class Session:
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -493,6 +505,7 @@ class Session:
                     keepalive_delay=keepalive_delay,
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
+                    allow_incoming_cookies=allow_incoming_cookies,
                 ),
             )
         else:
@@ -1357,6 +1370,7 @@ class Session:
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -1376,6 +1390,7 @@ class Session:
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
             self.mount(
@@ -1395,6 +1410,7 @@ class Session:
                     keepalive_delay=self._keepalive_delay,
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
+                    allow_incoming_cookies=self.allow_incoming_cookies,
                 ),
             )
 
@@ -1468,12 +1484,13 @@ class Session:
         r = dispatch_hook("response", hooks, r, **kwargs)  # type: ignore[arg-type]
 
         # Persist cookies
-        if r.history:
-            # If the hooks create history then we want those cookies too
-            for resp in r.history:
-                extract_cookies_to_jar(self.cookies, resp.request, resp.raw)
+        if self.allow_incoming_cookies:
+            if r.history:
+                # If the hooks create history then we want those cookies too
+                for resp in r.history:
+                    extract_cookies_to_jar(self.cookies, resp.request, resp.raw)
 
-        extract_cookies_to_jar(self.cookies, request, r.raw)
+            extract_cookies_to_jar(self.cookies, request, r.raw)
 
         # Resolve redirects if allowed.
         if allow_redirects:
@@ -1649,6 +1666,7 @@ class Session:
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         self.mount(
@@ -1668,6 +1686,7 @@ class Session:
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         self.mount(
@@ -1687,6 +1706,7 @@ class Session:
                 keepalive_delay=self._keepalive_delay,
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
+                allow_incoming_cookies=self.allow_incoming_cookies,
             ),
         )
         for adapter in self.adapters.values():
@@ -1843,7 +1863,8 @@ class Session:
             # Extract any cookies sent on the response to the cookiejar
             # in the new request. Because we've mutated our copied prepared
             # request, use the old one that we haven't yet touched.
-            extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
+            if self.allow_incoming_cookies:
+                extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
             merge_cookies(prepared_request._cookies, self.cookies)
             prepared_request.prepare_cookies(prepared_request._cookies)
 
@@ -1888,7 +1909,8 @@ class Session:
                 if hasattr(resp, "lazy") and resp.lazy:
                     resp.status_code
 
-                extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
+                if self.allow_incoming_cookies:
+                    extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 
                 # extract redirect url, if any, for the next loop
                 url = self.get_redirect_target(resp)

--- a/src/niquests/structures.py
+++ b/src/niquests/structures.py
@@ -50,8 +50,17 @@ def _ensure_str_or_bytes(key: typing.Any, value: typing.Any) -> tuple[bytes | st
 
 _T = typing.TypeVar("_T")
 
+if typing.TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class CaseInsensitiveDict(MutableMapping):
+    _KT = TypeVar("_KT", default="str | bytes")
+    _VT = TypeVar("_VT", default="str | bytes")
+else:
+    _KT = typing.TypeVar("_KT")
+    _VT = typing.TypeVar("_VT")
+
+
+class CaseInsensitiveDict(MutableMapping, typing.Generic[_KT, _VT]):
     """A case-insensitive ``dict``-like object.
 
     Implements all methods and operations of
@@ -99,57 +108,54 @@ class CaseInsensitiveDict(MutableMapping):
                     **kwargs,
                 )
 
-    def __setitem__(self, key: str | bytes, value: str | bytes) -> None:
+    def __setitem__(self, key: _KT, value: _VT) -> None:
         # Use the lowercased key for lookups, but store the actual
         # key alongside the value.
         self._store[_lower_wrapper(key)] = _ensure_str_or_bytes(key, value)
 
-    def __getitem__(self, key) -> bytes | str:
+    def __getitem__(self, key: _KT) -> _VT:
         e = self._store[_lower_wrapper(key)]
         if len(e) == 2:
-            return e[1]
+            return e[1]  # type: ignore[return-value]
         # this path should always be list[str] (if coming from urllib3.HTTPHeaderDict!)
         try:
-            return ", ".join(e[1:]) if isinstance(e[1], str) else b", ".join(e[1:])  # type: ignore[arg-type]
+            return ", ".join(e[1:]) if isinstance(e[1], str) else b", ".join(e[1:])  # type: ignore[arg-type,return-value]
         except TypeError:  # worst case scenario...
-            return ", ".join(v.decode() if isinstance(v, bytes) else v for v in e[1:])
+            return ", ".join(v.decode() if isinstance(v, bytes) else v for v in e[1:])  # type: ignore[return-value]
 
     @typing.overload  # type: ignore[override]
-    def get(self, key: str | bytes) -> str | bytes | None: ...
+    def get(self, key: _KT) -> _VT | None: ...
 
     @typing.overload
-    def get(self, key: str | bytes, default: str | bytes) -> str | bytes: ...
+    def get(self, key: _KT, default: _VT | _T) -> _VT | _T: ...
 
-    @typing.overload
-    def get(self, key: str | bytes, default: _T) -> str | bytes | _T: ...
-
-    def get(self, key: str | bytes, default: str | bytes | _T | None = None) -> str | bytes | _T | None:
+    def get(self, key: _KT, default: _VT | _T | None = None) -> _VT | _T | None:
         return super().get(key, default=default)
 
     def __delitem__(self, key) -> None:
         del self._store[_lower_wrapper(key)]
 
-    def __iter__(self) -> typing.Iterator[str | bytes]:
+    def __iter__(self) -> typing.Iterator[_KT]:
         for key_ci in self._store:
-            yield self._store[key_ci][0]
+            yield self._store[key_ci][0]  # type: ignore[misc]
 
     def __len__(self) -> int:
         return len(self._store)
 
-    def lower_items(self) -> typing.Iterator[tuple[bytes | str, bytes | str]]:
+    def lower_items(self) -> typing.Iterator[tuple[_KT, _VT]]:
         """Like iteritems(), but with all lowercase keys."""
-        return ((lowerkey, keyval[1]) for (lowerkey, keyval) in self._store.items())
+        return ((lowerkey, keyval[1]) for (lowerkey, keyval) in self._store.items())  # type: ignore[misc]
 
-    def items(self):
+    def items(self) -> typing.Iterator[tuple[_KT, _VT]]:  # type: ignore[override]
         for k in self._store:
             t = self._store[k]
             if len(t) == 2:
-                yield tuple(t)
+                yield tuple(t)  # type: ignore[misc]
             else:  # this case happen due to copying "_container" from HTTPHeaderDict!
                 try:
-                    yield t[0], ", ".join(t[1:])  # type: ignore[arg-type]
+                    yield t[0], ", ".join(t[1:])  # type: ignore[arg-type,misc]
                 except TypeError:
-                    yield (
+                    yield (  # type: ignore[misc]
                         t[0],
                         ", ".join(v.decode() if isinstance(v, bytes) else v for v in t[1:]),
                     )
@@ -163,14 +169,39 @@ class CaseInsensitiveDict(MutableMapping):
         return dict(self.lower_items()) == dict(other.lower_items())
 
     # Copy is required
-    def copy(self) -> CaseInsensitiveDict:
+    def copy(self) -> CaseInsensitiveDict[_KT, _VT]:
         return CaseInsensitiveDict(self)
 
     def __repr__(self) -> str:
         return str(dict(self.items()))
 
-    def __contains__(self, item: str) -> bool:  # type: ignore[override]
+    def __contains__(self, item: _KT) -> bool:  # type: ignore[override]
         return _lower_wrapper(item) in self._store
+
+    if typing.TYPE_CHECKING:
+
+        @typing.overload  # type: ignore[override,no-overload-impl]
+        def pop(self, key: _KT) -> _VT: ...
+        @typing.overload
+        def pop(self, key: _KT, default: _VT) -> _VT: ...
+        @typing.overload
+        def pop(self, key: _KT, default: _T) -> _VT | _T: ...
+
+        @typing.overload  # type: ignore[override,no-overload-impl]
+        def setdefault(self, key: _KT) -> _VT | None: ...
+        @typing.overload
+        def setdefault(self, key: _KT, default: _VT) -> _VT: ...
+
+        def popitem(self) -> tuple[_KT, _VT]: ...
+        def keys(self) -> typing.KeysView[_KT]: ...
+        def values(self) -> typing.ValuesView[_VT]: ...
+
+        @typing.overload  # type: ignore[override,no-overload-impl]
+        def update(self, m: typing.Mapping[_KT, _VT], **kwargs: _VT) -> None: ...
+        @typing.overload
+        def update(self, m: typing.Iterable[tuple[_KT, _VT]], **kwargs: _VT) -> None: ...
+        @typing.overload
+        def update(self, **kwargs: _VT) -> None: ...
 
 
 class LookupDict(dict):

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -61,6 +61,11 @@ from .packages.urllib3.contrib.webextensions._async import AsyncExtensionFromHTT
 from .packages.urllib3.util import make_headers, parse_url
 from .structures import CaseInsensitiveDict
 
+try:
+    from .packages.urllib3.contrib.anytls import BACKEND
+except ImportError:
+    BACKEND = "ssl"
+
 if typing.TYPE_CHECKING:
     from .cookies import RequestsCookieJar
     from .models import AsyncResponse, PreparedRequest, Request, Response
@@ -860,11 +865,20 @@ def default_user_agent(name: str = "niquests") -> str:
 
 
 def default_headers() -> CaseInsensitiveDict:
+    # utls backend = BoringSSL = Google Chrome target
+    # we shall not interfere with predefined headers from
+    # low-level ctx.
+    if BACKEND != "utls":
+        return CaseInsensitiveDict(
+            {
+                "User-Agent": default_user_agent(),
+                "Accept-Encoding": DEFAULT_ACCEPT_ENCODING,
+                "Accept": "*/*",
+                "Connection": "keep-alive",
+            }
+        )
     return CaseInsensitiveDict(
         {
-            "User-Agent": default_user_agent(),
-            "Accept-Encoding": DEFAULT_ACCEPT_ENCODING,
-            "Accept": "*/*",
             "Connection": "keep-alive",
         }
     )

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -432,11 +432,18 @@ class TestRequests:
 
     def test_cookielib_cookiejar_on_redirect(self, httpbin):
         """Tests resolve_redirect doesn't fail when merging cookies
-        with non-RequestsCookieJar cookiejar.
+        with a non-RequestsCookieJar cookiejar.
 
         See GH #3579
+
+        An unknown CookieJar subclass must be preserved as-is (not coerced into a
+        RequestsCookieJar) so that file-backed/custom jars keep their behavior.
         """
-        cj = cookiejar_from_dict({"foo": "bar"}, cookielib.CookieJar())
+
+        class CustomCookieJar(cookielib.CookieJar):
+            pass
+
+        cj = cookiejar_from_dict({"foo": "bar"}, CustomCookieJar())
         s = niquests.Session()
         s.cookies = cookiejar_from_dict({"cookie": "tasty"})
 
@@ -451,8 +458,8 @@ class TestRequests:
         redirects = s.resolve_redirects(resp, prep_req)
         resp = next(redirects)
 
-        # Verify CookieJar isn't being converted to RequestsCookieJar
-        assert isinstance(prep_req._cookies, cookielib.CookieJar)
+        # Verify the unknown CookieJar subclass isn't being converted to RequestsCookieJar
+        assert isinstance(prep_req._cookies, CustomCookieJar)
         assert isinstance(resp.request._cookies, cookielib.CookieJar)
         assert not isinstance(resp.request._cookies, niquests.cookies.RequestsCookieJar)
 
@@ -461,6 +468,17 @@ class TestRequests:
             cookies[c.name] = c.value
         assert cookies["foo"] == "bar"
         assert cookies["cookie"] == "tasty"
+
+    def test_plain_cookiejar_is_coerced_on_prepare(self):
+        """A plain stdlib CookieJar passed at request level is coerced (GH #401/#404)."""
+        cj = cookiejar_from_dict({"foo": "bar"}, cookielib.CookieJar())
+        assert type(cj) is cookielib.CookieJar
+
+        req = niquests.Request("GET", "http://example.com", cookies=cj)
+        prep = req.prepare()
+
+        assert isinstance(prep._cookies, niquests.cookies.RequestsCookieJar)
+        assert prep._cookies.get("foo") == "bar"
 
     def test_requests_in_history_are_not_overridden(self, httpbin):
         resp = niquests.get(httpbin("redirect/3"))
@@ -536,6 +554,59 @@ class TestRequests:
         """AsyncSession accepts custom auth at initialization."""
         s = niquests.AsyncSession(auth=init_auth)
         assert s.auth == expected_auth
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_params(self, session_cls):
+        """Session/AsyncSession accept default params at initialization (issue #400)."""
+        s = session_cls(params={"foo": "bar"})
+        assert s.params == {"foo": "bar"}
+        # default stays an empty dict when not provided
+        assert session_cls().params == {}
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_proxies(self, session_cls):
+        """Session/AsyncSession accept default proxies at initialization (issue #400)."""
+        s = session_cls(proxies={"https": "http://localhost:3128"})
+        assert s.proxies == {"https": "http://localhost:3128"}
+        assert session_cls().proxies == {}
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_verify_and_cert(self, session_cls):
+        """Session/AsyncSession accept default verify/cert at initialization (issue #400)."""
+        s = session_cls(verify=False, cert="/tmp/client.pem")
+        assert s.verify is False
+        assert s.cert == "/tmp/client.pem"
+        # defaults are preserved when not provided
+        default = session_cls()
+        assert default.verify is True
+        assert default.cert is None
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_cookies_from_dict(self, session_cls):
+        """Session/AsyncSession accept default cookies as a mapping (issue #400/#401)."""
+        s = session_cls(cookies={"foo": "bar"})
+        assert isinstance(s.cookies, niquests.cookies.RequestsCookieJar)
+        assert s.cookies.get("foo") == "bar"
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_cookies_coerce_native_jar(self, session_cls):
+        """A native CookieJar passed at init is silently coerced (issue #401/#404)."""
+        cj = cookiejar_from_dict({"foo": "bar"}, cookielib.CookieJar())
+        s = session_cls(cookies=cj)
+        # always exposed as a RequestsCookieJar so .get/.set work like a mapping
+        assert isinstance(s.cookies, niquests.cookies.RequestsCookieJar)
+        assert s.cookies.get("foo") == "bar"
+        # the mapping/method API is now available (issue #404)
+        s.cookies.set("baz", "qux")
+        assert s.cookies.get("baz") == "qux"
+
+    @pytest.mark.parametrize("session_cls", (niquests.Session, niquests.AsyncSession))
+    def test_session_init_cookies_passthrough_requests_jar(self, session_cls):
+        """A RequestsCookieJar passed at init is used as-is."""
+        jar = niquests.cookies.RequestsCookieJar()
+        jar.set("foo", "bar")
+        s = session_cls(cookies=jar)
+        assert s.cookies is jar
 
     @pytest.mark.parametrize("key", ("User-agent", "user-agent"))
     def test_user_agent_transfers(self, httpbin, key):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -370,6 +370,32 @@ class TestRequests:
         s.get(url)
         assert s.cookies["foo"] == "bar"
 
+    def test_allow_incoming_cookies_default_keeps_incoming(self, httpbin):
+        s = niquests.Session()
+        assert s.allow_incoming_cookies is True
+        s.get(httpbin("cookies/set?foo=bar"), allow_redirects=False)
+        assert s.cookies["foo"] == "bar"
+
+    def test_allow_incoming_cookies_false_ignores_incoming(self, httpbin):
+        s = niquests.Session(allow_incoming_cookies=False)
+        assert s.allow_incoming_cookies is False
+        r = s.get(httpbin("cookies/set?foo=bar"), allow_redirects=False)
+        # incoming cookies are not merged into the session jar
+        assert "foo" not in s.cookies
+        # but the server cookies are still reported on the response
+        assert r.cookies["foo"] == "bar"
+
+    def test_allow_incoming_cookies_false_still_sends_outgoing(self, httpbin):
+        s = niquests.Session(allow_incoming_cookies=False)
+        s.cookies.set("foo", "bar")
+        r = s.get(httpbin("cookies"))
+        assert r.json()["cookies"] == {"foo": "bar"}
+
+    def test_allow_incoming_cookies_false_on_redirect(self, httpbin):
+        s = niquests.Session(allow_incoming_cookies=False)
+        s.get(httpbin("cookies/set?foo=bar"))  # sets cookie then redirects
+        assert "foo" not in s.cookies
+
     def test_cookie_sent_on_redirect(self, httpbin):
         s = niquests.Session()
         r = s.get(httpbin("cookies/set?foo=bar"))

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -69,6 +69,10 @@ TARPIT = "http://10.255.255.1"
 INVALID_PROXY = "http://localhost:1"
 
 
+class _StopSend(Exception):
+    """Sentinel raised from a patched ``Session.send`` to capture the prepared URL without I/O."""
+
+
 class TestRequests:
     digest_auth_algo = ("MD5", "SHA-256", "SHA-512")
 
@@ -2654,6 +2658,7 @@ class RedirectSession(Session):
         self.max_redirects = 30
         self.cookies = {}
         self.trust_env = False
+        self.allow_incoming_cookies = True
 
     def send(self, *args, **kwargs):
         self.calls.append(SendCall(args, kwargs))
@@ -2934,6 +2939,47 @@ class TestPreparingURLs:
         prepared = r.prepare()
 
         assert prepared.url == "https://google.com"
+
+    @pytest.mark.parametrize(
+        "base_url, url, override_scheme, expected",
+        [
+            ("http://localhost:8080", "/events", "sse", "sse://localhost:8080/events"),
+            ("https://example.com", "/ws", "wss", "wss://example.com/ws"),
+            (
+                "http+unix://%2Ftmp%2Fx.sock",
+                "/events",
+                "sse+unix",
+                "sse+unix://%2Ftmp%2Fx.sock/events",
+            ),
+        ],
+    )
+    def test_override_scheme_with_base_url(self, base_url, url, override_scheme, expected):
+        s = niquests.Session(base_url=base_url)
+        captured = {}
+
+        def fake_send(prep, **kwargs):
+            captured["url"] = prep.url
+            raise _StopSend
+
+        s.send = fake_send
+        with pytest.raises(_StopSend):
+            s.get(url, override_scheme=override_scheme)
+
+        assert captured["url"] == expected
+
+    def test_override_scheme_ignored_without_base_url(self):
+        s = niquests.Session()
+        captured = {}
+
+        def fake_send(prep, **kwargs):
+            captured["url"] = prep.url
+            raise _StopSend
+
+        s.send = fake_send
+        with pytest.raises(_StopSend):
+            s.get("http://localhost:8080/events", override_scheme="sse")
+
+        assert captured["url"] == "http://localhost:8080/events"
 
     @pytest.mark.parametrize("url, exception", (("http://localhost:-1", InvalidURL),))
     def test_redirecting_to_bad_url(self, httpbin, url, exception):


### PR DESCRIPTION
3.19.0 (2026-06-01)
-------------------

**Added**
- `Session` and `AsyncSession` constructors now accept `params`, `cookies`, `proxies`, `verify` and `cert`
  so that per-request defaults can be configured at initialization, consistently with `headers` and `auth`. (#400)
  Ease forward the migration from httpx for interested users.
- A plain `http.cookiejar.CookieJar` (or a mapping) provided as `cookies` is now coerced into a
  `RequestsCookieJar`. The `Session`/`AsyncSession` constructor always coerces (so `session.cookies.set(...)`
  works), while at the request level an unknown `CookieJar` subclass (e.g. `MozillaCookieJar` or any
  file-backed/custom jar) is left untouched to preserve its behavior. (#401, #404)
- Support for the alternative TLS backend BoringSSL via the `utls` extra.
  Niquests now offer a first-class TLS browser impersonation without ever-changing your http client.
  It is automatically done (e.g. negotiated) once the extra is installed. You will need to keep it
  regularly updated so that you have the latest TLS specs of modern browsers.
- `Session` and `AsyncSession` constructors now accept `allow_incoming_cookies` (defaults to `True`).
  Set it to `False` to ignore every cookie sent by the remote peer (via `Set-Cookie`) so that nothing
  is merged into the session jar, including cookies carried across redirect hops. Outgoing cookies you
  set yourself are still emitted.
- `Session.request`/`AsyncSession.request` (and the verb shortcuts) now accept an `override_scheme`
  keyword argument. When a `base_url` is set on the Session, it override the scheme of the final
  (merged) URL just before the adapter is picked, so you can target a different scheme (e.g. `sse`,
  `ws`/`wss`, optionally with an implementation suffix like `sse+unix`) without retyping the full URL. (#325)

**Changed**
- The `cookies` attribute of `Session`, `AsyncSession` and `Response` is now always typed as
  `RequestsCookieJar` instead of `RequestsCookieJar | CookieJar`. This restores the ergonomic mapping
  interface (e.g. `session.cookies.set(...)`) when using static type checkers. (#401, #404)

  This is **not** a runtime breaking change: reading `.cookies` is unchanged, and a native `CookieJar`
  is still accepted everywhere it is passed as an argument (it is coerced when relevant). We do,
  however, acknowledge a static-typing trade-off: assigning a custom/non-`RequestsCookieJar` jar
  directly to the attribute (e.g. `session.cookies = MozillaCookieJar(...)`) now makes type checkers
  such as mypy complain, since the attribute is annotated as `RequestsCookieJar`. The assignment keeps
  working at runtime; if you rely on it, add a `# type: ignore`. We chose narrowing on
  purpose the predominant path is that `RequestsCookieJar` is expected while subclasses (custom implementation)
  are a niche usage.
- `CaseInsensitiveDict` is now generic over its key and value types (`CaseInsensitiveDict[_KT, _VT]`,
  mirroring `dict`/`Mapping`), and `Response.headers`/`Response.trailers` are typed as
  `CaseInsensitiveDict[str, str]`. Reading a response header (e.g. `response.headers["Content-Type"]`)
  now yields `str` instead of `str | bytes`, removing the need for a `cast`/`assert` to use the headers
  as a plain string mapping with static type checkers. (#401)

  This is purely a typing improvement with **no runtime change**: the class still subclasses
  `collections.abc.MutableMapping` (it merely also gains `typing.Generic`), so the Python 3.7 floor and
  the existing behavior are preserved, and no new dependency is introduced. Unsubscripted
  `CaseInsensitiveDict` keeps its historical `str | bytes` key/value types, so existing annotations are
  unaffected.