### PR TITLE
Fix the default in allow_redirects param description of head()

### DIFF
--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -305,7 +305,7 @@ def head(
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
     :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
-            Defaults to ``True``.
+            Defaults to ``False``.
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a path passed as a string or os.Pathlike object,


### PR DESCRIPTION
Probably a copy-paste issue.