### PR TITLE
Release 3.19.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+3.19.1 (2026-06-08)
+-------------------
+
+**Fixed**
+- Relative `Location` redirects no longer raise `MissingSchema` when the request targets a
+  synthetic scheme such as `wsgi://` or `asgi://`. (#406)
+
 3.19.0 (2026-06-01)
 -------------------
 

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.19.0"
+__version__ = "3.19.1"
 
-__build__: int = 0x031900
+__build__: int = 0x031901
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -893,7 +893,7 @@ class AsyncSession(Session):
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
             # Compliant with RFC3986, we percent encode the url.
             if not parsed.netloc:
-                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var]
+                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var,arg-type]
                 assert isinstance(url, str), f"urljoin produced {type(url)} instead of str"
             else:
                 url = requote_uri(url)

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -7,7 +7,7 @@ import typing
 import warnings
 from collections import OrderedDict
 from datetime import timedelta
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from .status_codes import codes
 
@@ -94,6 +94,7 @@ from .utils import (
     rewind_body,
     should_check_crl,
     should_check_ocsp,
+    urljoin_safe,
 )
 
 # Preferred clock, based on which one is more accurate on a given system.
@@ -892,7 +893,7 @@ class AsyncSession(Session):
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
             # Compliant with RFC3986, we percent encode the url.
             if not parsed.netloc:
-                url = urljoin(resp.url, requote_uri(url))  # type: ignore[type-var]
+                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var]
                 assert isinstance(url, str), f"urljoin produced {type(url)} instead of str"
             else:
                 url = requote_uri(url)

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -1838,7 +1838,7 @@ class Session:
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
             # Compliant with RFC3986, we percent encode the url.
             if not parsed.netloc:
-                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var]
+                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var,arg-type]
                 assert isinstance(url, str), f"urljoin produced {type(url)} instead of str"
             else:
                 url = requote_uri(url)

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import timedelta
 from http import cookiejar as cookielib
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from ._compat import HAS_LEGACY_URLLIB3, iscoroutinefunction, urllib3_ensure_type
 from ._constant import (
@@ -109,6 +109,7 @@ from .utils import (  # noqa: F401
     should_check_crl,
     should_check_ocsp,
     to_key_val_list,
+    urljoin_safe,
 )
 
 # Preferred clock, based on which one is more accurate on a given system.
@@ -1837,7 +1838,7 @@ class Session:
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
             # Compliant with RFC3986, we percent encode the url.
             if not parsed.netloc:
-                url = urljoin(resp.url, requote_uri(url))  # type: ignore[type-var]
+                url = urljoin_safe(resp.url, requote_uri(url))  # type: ignore[type-var]
                 assert isinstance(url, str), f"urljoin produced {type(url)} instead of str"
             else:
                 url = requote_uri(url)

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from functools import lru_cache
 from http.cookiejar import CookieJar
 from netrc import NetrcParseError, netrc
-from urllib.parse import quote, unquote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urljoin, urlparse, urlunparse, uses_relative
 from urllib.request import (  # type: ignore[attr-defined]  # type: ignore[attr-defined]
     getproxies,
     getproxies_environment,
@@ -1185,6 +1185,29 @@ def parse_scheme(url: str, default: str | None = None, max_length: int = 11) -> 
         raise MissingSchema(f"Invalid URL {url!r}: No scheme supplied. Perhaps you meant https://{url}?") from e
 
     return scheme.lower()
+
+
+def urljoin_safe(base: str, url: str) -> str:
+    """RFC 3986 relative join that also works for niquests' synthetic schemes."""
+    scheme = parse_scheme(base, default="")
+
+    # see https://github.com/jawah/niquests/issues/406
+    # to learn about origin story!
+    if not scheme or scheme in uses_relative:
+        return urljoin(base, url)
+
+    # The scheme is always a literal prefix of ``base``; swap it for one that
+    # urljoin understands.
+    temp = "https" + base[len(scheme) :]
+    joined = urljoin(temp, url)
+
+    # Only restore the scheme when the join produced a relative resolution.
+    # An absolute target (e.g. ``mailto:``, ``data:``) keeps its own scheme and
+    # must pass through untouched.
+    if joined.startswith("https://"):
+        return scheme + joined[len("https") :]
+
+    return joined
 
 
 def is_ocsp_capable(conn_info: ConnectionInfo | None) -> bool:

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi import FastAPI, Request, WebSocket
 from fastapi.responses import JSONResponse
 from niquests.packages.urllib3.contrib.webextensions.sse import ServerSentEvent
-from starlette.responses import StreamingResponse
+from starlette.responses import RedirectResponse, StreamingResponse
 
 from niquests import AsyncSession, RetryConfiguration, Session
 
@@ -81,6 +81,16 @@ async def echo(request: Request):
         "body": body,
         "headers": dict(request.headers),
     }
+
+
+@app.get("/redirect-me")
+async def redirect_me():
+    return RedirectResponse(url="/path/to/home", status_code=302)
+
+
+@app.get("/path/to/home")
+async def home():
+    return {"message": "home"}
 
 
 @pytest.mark.asyncio
@@ -319,3 +329,23 @@ def test_thread_asgi_sse_send_forbidden():
             ext.send_payload("nope")
 
         ext.close()
+
+
+@pytest.mark.asyncio
+async def test_asgi_relative_redirect_not_followed():
+    # Regression for jawah/niquests#406: a relative Location with an asgi://
+    # base url used to raise MissingSchema even when allow_redirects=False.
+    async with AsyncSession(app=app) as s:
+        resp = await s.get("/redirect-me", allow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/path/to/home"
+
+
+@pytest.mark.asyncio
+async def test_asgi_relative_redirect_followed():
+    async with AsyncSession(app=app) as s:
+        resp = await s.get("/redirect-me", allow_redirects=True)
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "home"
+        assert len(resp.history) == 1
+        assert resp.url == "asgi://default/path/to/home"

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -62,6 +62,16 @@ def echo():
     )
 
 
+@app.route("/redirect-me")
+def redirect_me():
+    return FlaskResponse(status=302, headers={"Location": "/path/to/home"})
+
+
+@app.route("/path/to/home")
+def home():
+    return jsonify({"message": "home"})
+
+
 def test_wsgi_basic():
     with Session(app=app) as s:
         resp = s.get("/hello?foo=bar")
@@ -154,3 +164,22 @@ def test_wsgi_websocket_not_supported():
             s.get("ws://default/ws-echo")
         assert isinstance(exc_info.value.reason, NotImplementedError)
         assert "WebSocket is not supported over WSGI" in str(exc_info.value.reason)
+
+
+def test_wsgi_relative_redirect_not_followed():
+    # Regression for jawah/niquests#406: a relative Location with a wsgi://
+    # base url used to raise MissingSchema even when allow_redirects=False.
+    with Session(app=app) as s:
+        resp = s.get("/redirect-me", allow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/path/to/home"
+
+
+def test_wsgi_relative_redirect_followed():
+    with Session(app=app) as s:
+        resp = s.get("/redirect-me", allow_redirects=True)
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "home"
+        assert len(resp.history) == 1
+        assert resp.url == "wsgi://default/path/to/home"
+

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -182,4 +182,3 @@ def test_wsgi_relative_redirect_followed():
         assert resp.json()["message"] == "home"
         assert len(resp.history) == 1
         assert resp.url == "wsgi://default/path/to/home"
-


### PR DESCRIPTION
3.19.1 (2026-06-08)
-------------------

**Fixed**
- Relative `Location` redirects no longer raise `MissingSchema` when the request targets a
  synthetic scheme such as `wsgi://` or `asgi://`. (#406)
