### PR TITLE
Use a file object in the vcrpy async integration example

### DIFF
--- a/docs/community/extensions.rst
+++ b/docs/community/extensions.rst
@@ -713,6 +713,7 @@ Add the following to your ``conftest.py``:
     import functools
     import itertools
     import logging
+    from io import BytesIO
     from unittest import mock
 
     import pytest
@@ -765,7 +766,7 @@ Add the following to your ``conftest.py``:
         if isinstance(body, str):
             body = body.encode("utf-8")
         return AsyncHTTPResponse(
-            body=body,
+            body=BytesIO(body),
             status=vcr_response["status"]["code"],
             reason=vcr_response["status"]["message"],
             headers=_deserialize_headers(headers),


### PR DESCRIPTION
For some reason that makes this go away:
```
.tox/py314/lib64/python3.14/site-packages/niquests/models.py:1503: in json
    raise RequestsJSONDecodeError("response content is not JSON", "", 0)
```

I had these in that env:
```
asgiref                   3.11.1
asttokens                 3.0.1
attrs                     26.1.0
blinker                   1.9.0
brotli                    1.2.0
brotlicffi                1.2.0.1
certifi                   2026.5.20
cffi                      2.0.0
chardet                   6.0.0.post1
charset-normalizer        3.4.7
click                     8.4.1
coverage                  7.14.1
DateTimeRange             2.3.2
decorator                 5.3.1
defusedxml                0.7.1
diff-match-patch          20241021
Django                    6.0.4
django-crispy-forms       2.6
django-import-export      4.4.0
django-phonenumber-field  8.4.0
django-rosetta            0.10.3
djangorestframework       3.17.1
executing                 2.2.1
flasgger                  0.9.7.1
Flask                     3.1.3
greenlet                  3.5.1
h11                       0.16.0
httpbin                   0.10.3
hunter                    3.9.0
idna                      3.18
iniconfig                 2.3.0
inline-snapshot           0.34.1
itsdangerous              2.2.0
jh2                       5.0.13
Jinja2                    3.1.6
jsonschema                4.26.0
jsonschema-specifications 2025.9.1
manhole                   1.8.1
markdown-it-py            4.2.0
MarkupSafe                3.0.3
mbstrdecoder              1.1.5
mdurl                     0.1.2
mistune                   3.2.1
niquests                  3.18.6
packaging                 26.2
phonenumberslite          9.0.28
pip                       26.1.2
pluggy                    1.6.0
polib                     1.2.0
process-tests             3.0.0
pycparser                 3.0
Pygments                  2.20.0
pytest                    9.1.0
pytest-asyncio            1.4.0
pytest-cov                7.1.0
pytest-django             4.12.0
pytest-httpbin            2.1.0
pytest-mock               3.15.1
pytest-recording          0.13.4
python-dateutil           2.9.0.post0
pytz                      2026.2
PyYAML                    6.0.3
qh3                       1.9.2
referencing               0.37.0
requests                  2.34.2
rich                      15.0.0
rpds-py                   2026.5.1
six                       1.17.0
sqlparse                  0.5.5
tablib                    3.9.0
time-machine              3.2.0
typepy                    1.3.5
typing_extensions         4.15.0
urllib3                   2.7.0
urllib3-future            2.21.902
vcrpy                     8.2.1
wassima                   2.1.1
Werkzeug                  3.1.8
wrapt                     2.2.1
```