### PR TITLE
Fix: fix overloads for `AsyncResponse.iter_lines()`

### DIFF
--- a/src/niquests/models.py
+++ b/src/niquests/models.py
@@ -1850,7 +1850,7 @@ class AsyncResponse(Response):
         return generate()
 
     @typing.overload  # type: ignore[override]
-    async def iter_lines(
+    def iter_lines(
         self,
         chunk_size: int = ...,
         decode_unicode: Literal[False] = ...,
@@ -1858,7 +1858,7 @@ class AsyncResponse(Response):
     ) -> typing.AsyncGenerator[bytes, None]: ...
 
     @typing.overload  # type: ignore[override]
-    async def iter_lines(
+    def iter_lines(
         self,
         chunk_size: int = ...,
         *,


### PR DESCRIPTION
> An solution mentioned in #411.

During #185 there are typing fixes for `iter_content()`, `iter_raw()`, and `iter_lines()` in `AsyncResponse`. However only the former twos are async functions returning async generators (`await` needed before `async for`), and the latter one is a real async generator (cannot be `await`ed), so `iter_lines()` should have a normal overload form of async generators.

References:
- https://typing.python.org/en/latest/spec/overload.html#implementation-consistency
- https://github.com/microsoft/pyright/issues/10746