### PR TITLE
Release 3.20.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@ Release History
 - A `TLSConfiguration` object to let you take a deeper control over the TLS configuration.
   This object will allow you to change min, max TLS version, as the cipher list and finally the desired TLS backend.
 
+**Fixed**
+- Typing overload for `AsyncResponse` iter_lines method. (#413)
+
 3.19.1 (2026-06-08)
 -------------------
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,15 @@
 Release History
 ===============
 
+3.20.0 (2026-06-26)
+-------------------
+
+**Added**
+- Method/Verb `QUERY` as one of the promoted HTTP verb and available through top level function shortcuts and `Session`/`AsyncSession` methods.
+  This is following the RFC 10008. A long awaited standardized verb. Any other non-standard verb is still supported through manual `request(...)` calls.
+- A `TLSConfiguration` object to let you take a deeper control over the TLS configuration.
+  This object will allow you to change min, max TLS version, as the cipher list and finally the desired TLS backend.
+
 3.19.1 (2026-06-08)
 -------------------
 

--- a/docs/community/extensions.rst
+++ b/docs/community/extensions.rst
@@ -167,8 +167,6 @@ It can also be used as a decorator:
 
 .. _niquests-mock: https://pypi.org/project/niquests-mock/
 
-.. _opentelemetry-instrumentation-niquests:
-
 opentelemetry-instrumentation-niquests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -2101,6 +2101,16 @@ If you see the TLS backend being "BoringSSL (OpenSSL 1.1.1 compatible)" then you
 .. note:: If you are getting blocked, come and get in touch with us through our Github issues. We'll help unblock the situation. We usually keep updating ``utls`` regularly to ensure we are up-to-date with latest browsers.
 .. warning:: Being able to unblock access via a proper TLS fingerprint does not prevent you from being IP blacklisted. Providers are smart, they know some services can't exceed 1 RPS. You'll need proxies to extend RPS targets.
 
+.. versionadded:: 3.20.0
+
+You can enforce a specific TLS backend through Niquests ``tls_configuration`` kwargs in ``Session`` or ``AsyncSession``.
+Following this example::
+
+    import niquests
+
+    s = niquests.Session(tls_configuration=niquests.TLSConfiguration(backend="utls"))
+    s.get("https://my-hard-to-access-url.tld/")  # should be okay now
+
 Tracking the real download speed
 --------------------------------
 
@@ -2267,6 +2277,16 @@ against aws-lc-rs.
 
 It's a memory-safe TLS backend. To learn more about it, visit https://github.com/jawah/rtls
 Any issue encountered with it should be reported directly to the linked repository.
+
+.. versionadded:: 3.20.0
+
+Following this example, you can programmatically enforce a specific TLS backend::
+
+    import niquests
+
+    s = niquests.Session(tls_configuration=niquests.TLSConfiguration(backend="rtls"))
+
+.. note:: This is useful when the user may have multiple TLS backends installed in the environment.
 
 Encrypted Client Hello
 ----------------------

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -596,6 +596,35 @@ to not care about root CAs. By default it is expected to use your operating syst
 You have nothing to do. If we were unable to access your OS truststore natively, (e.g. not Windows, not MacOS, not Linux), then
 we will fallback on the ``certifi`` bundle.
 
+.. _tls-configuration:
+
+TLS Configuration
+-----------------
+
+.. versionadded:: 3.20.0
+
+For a finer control over the TLS layer, you may pass a :class:`~niquests.TLSConfiguration` to your
+:class:`~niquests.Session`. It lets you pick the desired TLS backend, restrict the negotiated TLS
+version, and tune the cipher list::
+
+    from niquests import Session, TLSConfiguration
+    from niquests.packages.urllib3.contrib.anytls import ssl
+
+    tls_config = TLSConfiguration(
+        backend="ssl",  # one of "ssl", "utls", or "rtls"
+        min_version=ssl.TLSVersion.TLSv1_2,
+        max_version=ssl.TLSVersion.TLSv1_3,
+        # also "ciphers" arg is available..!
+    )
+
+    with Session(tls_configuration=tls_config) as s:
+        s.get("https://1.1.1.1")
+
+Every field is optional; leave it to ``None`` to keep the default behavior.
+
+.. note:: Selecting ``backend`` requires urllib3-future 2.22.900 or later. With an older version the
+  setting is ignored and a warning is emitted; the other options remain effective.
+
 .. _HTTP persistent connection: https://en.wikipedia.org/wiki/HTTP_persistent_connection
 .. _connection pooling: https://urllib3.readthedocs.io/en/latest/reference/index.html#module-urllib3.connectionpool
 .. _wassima: https://github.com/jawah/wassima

--- a/src/niquests/__init__.py
+++ b/src/niquests/__init__.py
@@ -47,6 +47,7 @@ from logging import NullHandler
 
 from ._compat import HAS_LEGACY_URLLIB3
 from .extensions.revocation import RevocationConfiguration, RevocationStrategy
+from .extensions.tls import TLSConfiguration
 from .packages.urllib3 import (
     Retry as RetryConfiguration,
 )
@@ -73,7 +74,7 @@ from .__version__ import (
     __url__,
     __version__,
 )
-from .api import delete, get, head, options, patch, post, put, request
+from .api import delete, get, head, options, patch, post, put, query, request
 from .async_api import (
     delete as adelete,
 )
@@ -94,6 +95,9 @@ from .async_api import (
 )
 from .async_api import (
     put as aput,
+)
+from .async_api import (
+    query as aquery,
 )
 from .async_api import (
     request as arequest,
@@ -146,6 +150,7 @@ __all__ = (
     "patch",
     "post",
     "put",
+    "query",
     "request",
     "adelete",
     "aget",
@@ -154,6 +159,7 @@ __all__ = (
     "apatch",
     "apost",
     "aput",
+    "aquery",
     "arequest",
     "ConnectionError",
     "ConnectTimeout",
@@ -184,4 +190,5 @@ __all__ = (
     "RevocationConfiguration",
     "RevocationStrategy",
     "ServerSentEvent",
+    "TLSConfiguration",
 )

--- a/src/niquests/__version__.py
+++ b/src/niquests/__version__.py
@@ -9,9 +9,9 @@ __description__: str = "Python HTTP for Humans."
 __url__: str = "https://niquests.readthedocs.io"
 
 __version__: str
-__version__ = "3.19.1"
+__version__ = "3.20.0"
 
-__build__: int = 0x031901
+__build__: int = 0x032000
 __author__: str = "Kenneth Reitz"
 __author_email__: str = "me@kennethreitz.org"
 __license__: str = "Apache-2.0"

--- a/src/niquests/adapters.py
+++ b/src/niquests/adapters.py
@@ -48,6 +48,7 @@ from .exceptions import (
     TooManyRedirects,
 )
 from .extensions.revocation import DEFAULT_STRATEGY, RevocationConfiguration
+from .extensions.tls import TLSConfiguration
 from .hooks import async_dispatch_hook, dispatch_hook
 from .models import AsyncResponse, PreparedRequest, Response
 from .packages.urllib3 import (
@@ -129,6 +130,7 @@ from .utils import (
     select_proxy,
     should_check_crl,
     should_check_ocsp,
+    tls_configuration_to_pool_kwargs,
     urldefragauth,
     wrap_extension_for_http,
 )
@@ -295,6 +297,7 @@ class HTTPAdapter(BaseAdapter):
         "_keepalive_idle_window",
         "_revocation_configuration",
         "_allow_incoming_cookies",
+        "_tls_configuration",
     ]
 
     def __init__(
@@ -318,6 +321,7 @@ class HTTPAdapter(BaseAdapter):
         keepalive_idle_window: float | int | None = 60.0,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         allow_incoming_cookies: bool = True,
+        tls_configuration: TLSConfiguration | None = None,
     ):
         if isinstance(max_retries, bool):
             self.max_retries: RetryType = False
@@ -364,6 +368,8 @@ class HTTPAdapter(BaseAdapter):
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
 
         self._allow_incoming_cookies: bool = allow_incoming_cookies
+
+        self._tls_configuration: TLSConfiguration | None = tls_configuration
 
         disabled_svn = set()
 
@@ -455,6 +461,9 @@ class HTTPAdapter(BaseAdapter):
         self._pool_block = block
         self._quic_cache_layer = quic_cache_layer
 
+        for key, value in tls_configuration_to_pool_kwargs(getattr(self, "_tls_configuration", None)).items():
+            pool_kwargs.setdefault(key, value)
+
         self.poolmanager = PoolManager(
             num_pools=connections,
             maxsize=maxsize,
@@ -481,6 +490,9 @@ class HTTPAdapter(BaseAdapter):
 
         if self._source_address and "source_address" not in proxy_kwargs:
             proxy_kwargs["source_address"] = self._source_address
+
+        for key, value in tls_configuration_to_pool_kwargs(getattr(self, "_tls_configuration", None)).items():
+            proxy_kwargs.setdefault(key, value)
 
         if proxy in self.proxy_manager:
             manager = self.proxy_manager[proxy]
@@ -1378,6 +1390,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         "_keepalive_idle_window",
         "_revocation_configuration",
         "_allow_incoming_cookies",
+        "_tls_configuration",
     ]
 
     def __init__(
@@ -1401,6 +1414,7 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         keepalive_idle_window: float | int | None = 60.0,
         revocation_configuration: RevocationConfiguration | None = DEFAULT_STRATEGY,
         allow_incoming_cookies: bool = True,
+        tls_configuration: TLSConfiguration | None = None,
     ):
         if isinstance(max_retries, bool):
             self.max_retries: RetryType = False
@@ -1448,6 +1462,8 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
 
         self._allow_incoming_cookies: bool = allow_incoming_cookies
+
+        self._tls_configuration: TLSConfiguration | None = tls_configuration
 
         disabled_svn = set()
 
@@ -1539,6 +1555,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
         self._pool_block = block
         self._quic_cache_layer = quic_cache_layer
 
+        for key, value in tls_configuration_to_pool_kwargs(getattr(self, "_tls_configuration", None)).items():
+            pool_kwargs.setdefault(key, value)
+
         self.poolmanager = AsyncPoolManager(
             num_pools=connections,
             maxsize=maxsize,
@@ -1565,6 +1584,9 @@ class AsyncHTTPAdapter(AsyncBaseAdapter):
 
         if self._source_address and "source_address" not in proxy_kwargs:
             proxy_kwargs["source_address"] = self._source_address
+
+        for key, value in tls_configuration_to_pool_kwargs(getattr(self, "_tls_configuration", None)).items():
+            proxy_kwargs.setdefault(key, value)
 
         if proxy in self.proxy_manager:
             manager = self.proxy_manager[proxy]

--- a/src/niquests/api.py
+++ b/src/niquests/api.py
@@ -638,3 +638,85 @@ def delete(
         retries=retries,
         **kwargs,
     )
+
+
+def query(
+    url: str,
+    data: BodyType | None = None,
+    json: typing.Any | None = None,
+    *,
+    params: QueryParameterType | None = None,
+    headers: HeadersType | None = None,
+    cookies: CookiesType | None = None,
+    files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+    auth: HttpAuthenticationType | None = None,
+    timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+    allow_redirects: bool = True,
+    proxies: ProxyType | None = None,
+    verify: TLSVerifyType = True,
+    stream: bool = False,
+    cert: TLSClientCertType | None = None,
+    hooks: HookType[PreparedRequest | Response] | None = None,
+    retries: RetryType = DEFAULT_RETRIES,
+) -> Response:
+    r"""Sends a QUERY request. This does not keep the connection alive. Use a :class:`Session` to reuse the connection.
+
+    The QUERY method (:rfc:`10008`) requests that the server process the enclosed content as a query and
+    respond with the result. It is similar to POST in that the query is carried in the request body, but
+    unlike POST it is safe and idempotent, allowing requests to be cached and automatically retried.
+
+    :param url: URL for the new :class:`Request` object.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the :class:`Request`.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the :class:`Request`.
+    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
+    :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
+    :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
+        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
+        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
+        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
+        to add for the file.
+    :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
+    :param timeout: (optional) How many seconds to wait for the server to send data
+        before giving up, as a float, or a :ref:`(connect timeout, read
+        timeout) <timeouts>` tuple.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
+    :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
+    :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a path passed as a string or os.Pathlike object,
+            in which case it must be a path to a CA bundle to use.
+            Defaults to ``True``.
+            It is also possible to put the certificates (directly) in a string or bytes.
+    :param stream: (optional) if ``False``, the response content will be immediately downloaded.
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
+    :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
+            Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
+
+    :return: :class:`Response <Response>` object
+    """
+
+    return request(
+        "QUERY",
+        url,
+        data=data,
+        json=json,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        files=files,
+        auth=auth,
+        timeout=timeout,
+        allow_redirects=allow_redirects,
+        proxies=proxies,
+        verify=verify,
+        stream=stream,
+        cert=cert,
+        hooks=hooks,
+        retries=retries,
+    )

--- a/src/niquests/async_api.py
+++ b/src/niquests/async_api.py
@@ -975,3 +975,129 @@ async def delete(
         retries=retries,
         **kwargs,
     )
+
+
+@typing.overload
+async def query(
+    url: str,
+    data: BodyType | AsyncBodyType | None = ...,
+    json: typing.Any | None = ...,
+    *,
+    params: QueryParameterType | None = ...,
+    headers: HeadersType | None = ...,
+    cookies: CookiesType | None = ...,
+    files: MultiPartFilesType | MultiPartFilesAltType | None = ...,
+    auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = ...,
+    timeout: TimeoutType | None = ...,
+    allow_redirects: bool = ...,
+    proxies: ProxyType | None = ...,
+    hooks: AsyncHookType[PreparedRequest | Response] | None = ...,
+    verify: TLSVerifyType | None = ...,
+    stream: typing.Literal[False] | typing.Literal[None] = ...,
+    cert: TLSClientCertType | None = ...,
+    retries: RetryType = ...,
+) -> Response: ...
+
+
+@typing.overload
+async def query(
+    url: str,
+    data: BodyType | AsyncBodyType | None = ...,
+    json: typing.Any | None = ...,
+    *,
+    params: QueryParameterType | None = ...,
+    headers: HeadersType | None = ...,
+    cookies: CookiesType | None = ...,
+    files: MultiPartFilesType | MultiPartFilesAltType | None = ...,
+    auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = ...,
+    timeout: TimeoutType | None = ...,
+    allow_redirects: bool = ...,
+    proxies: ProxyType | None = ...,
+    hooks: AsyncHookType[PreparedRequest | Response] | None = ...,
+    verify: TLSVerifyType | None = ...,
+    stream: typing.Literal[True],
+    cert: TLSClientCertType | None = ...,
+    retries: RetryType = ...,
+) -> AsyncResponse: ...
+
+
+async def query(
+    url: str,
+    data: BodyType | AsyncBodyType | None = None,
+    json: typing.Any | None = None,
+    *,
+    params: QueryParameterType | None = None,
+    headers: HeadersType | None = None,
+    cookies: CookiesType | None = None,
+    files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+    auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = None,
+    timeout: TimeoutType | None = WRITE_DEFAULT_TIMEOUT,
+    allow_redirects: bool = True,
+    proxies: ProxyType | None = None,
+    hooks: AsyncHookType[PreparedRequest | Response] | None = None,
+    verify: TLSVerifyType | None = None,
+    stream: bool | None = None,
+    cert: TLSClientCertType | None = None,
+    retries: RetryType = DEFAULT_RETRIES,
+) -> Response | AsyncResponse:
+    r"""Sends a QUERY request. This does not keep the connection alive. Use an :class:`AsyncSession` to reuse the connection.
+
+    The QUERY method (:rfc:`10008`) requests that the server process the enclosed content as a query and
+    respond with the result. It is similar to POST in that the query is carried in the request body, but
+    unlike POST it is safe and idempotent, allowing requests to be cached and automatically retried.
+
+    :param url: URL for the new :class:`Request` object.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the :class:`Request`.
+    :param data: (optional) Dictionary, list of tuples, bytes, or (awaitable or not) file-like
+        object to send in the body of the :class:`Request`.
+    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
+    :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
+    :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``)
+        for multipart encoding upload.
+        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
+        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string
+        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
+        to add for the file.
+    :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
+    :param timeout: (optional) How many seconds to wait for the server to send data
+        before giving up, as a float, or a :ref:`(connect timeout, read
+        timeout) <timeouts>` tuple.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection.
+            Defaults to ``True``.
+    :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
+    :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a path passed as a string or os.Pathlike object,
+            in which case it must be a path to a CA bundle to use.
+            Defaults to ``True``.
+            It is also possible to put the certificates (directly) in a string or bytes.
+    :param stream: (optional) if ``False``, the response content will be immediately downloaded. Otherwise, the response will
+            be of type :class:`AsyncResponse <AsyncResponse>` so that it will be awaitable.
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+    :param hooks: (optional) Register functions that should be called at very specific moment in the request lifecycle.
+    :param retries: (optional) If integer, determine the number of retry in case of a timeout or connection error.
+            Otherwise, for fine gained retry, use directly a ``Retry`` instance from urllib3.
+
+    :return: :class:`Response <Response>` object if stream=None or False. Otherwise :class:`AsyncResponse <AsyncResponse>`
+    """
+    return await request(  # type: ignore[misc]
+        "QUERY",
+        url,
+        data=data,
+        json=json,
+        params=params,
+        headers=headers,
+        cookies=cookies,
+        files=files,
+        auth=auth,
+        timeout=timeout,
+        allow_redirects=allow_redirects,
+        proxies=proxies,
+        verify=verify,
+        stream=stream,  # type: ignore[arg-type]
+        cert=cert,
+        hooks=hooks,
+        retries=retries,
+    )

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -36,6 +36,7 @@ from .exceptions import (
 )
 from .extensions.revocation import DEFAULT_STRATEGY, RevocationConfiguration
 from .extensions.sgi._async import AsyncServerGatewayInterface
+from .extensions.tls import TLSConfiguration
 from .extensions.unixsocket._async import AsyncUnixAdapter
 
 try:
@@ -154,6 +155,7 @@ class AsyncSession(Session):
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
         allow_incoming_cookies: bool = True,
+        tls_configuration: TLSConfiguration | None = None,
     ):
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -283,6 +285,9 @@ class AsyncSession(Session):
         #: How we should handle the revocation check for TLS newly acquired connection.
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
 
+        #: Fine-grained TLS configuration (backend, min/max version, ciphers) propagated to adapters.
+        self._tls_configuration: TLSConfiguration | None = tls_configuration
+
         # Default connection adapters.
         self.adapters: OrderedDict[str, AsyncBaseAdapter] = OrderedDict()  # type: ignore[assignment]
 
@@ -306,6 +311,7 @@ class AsyncSession(Session):
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
             self.mount(
@@ -326,6 +332,7 @@ class AsyncSession(Session):
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
             self.mount(
@@ -346,6 +353,7 @@ class AsyncSession(Session):
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
         else:
@@ -404,6 +412,7 @@ class AsyncSession(Session):
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
                 allow_incoming_cookies=self.allow_incoming_cookies,
+                tls_configuration=self._tls_configuration,
             ),
         )
         self.mount(
@@ -424,6 +433,7 @@ class AsyncSession(Session):
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
                 allow_incoming_cookies=self.allow_incoming_cookies,
+                tls_configuration=self._tls_configuration,
             ),
         )
         self.mount(
@@ -667,6 +677,7 @@ class AsyncSession(Session):
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
                     allow_incoming_cookies=self.allow_incoming_cookies,
+                    tls_configuration=self._tls_configuration,
                 ),
             )
             self.mount(
@@ -687,6 +698,7 @@ class AsyncSession(Session):
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
                     allow_incoming_cookies=self.allow_incoming_cookies,
+                    tls_configuration=self._tls_configuration,
                 ),
             )
             self.mount(

--- a/src/niquests/async_session.py
+++ b/src/niquests/async_session.py
@@ -1105,7 +1105,7 @@ class AsyncSession(Session):
         # Ensuring we always apply a default timeout as per Niquests policy.
         if send_kwargs["timeout"] is None:
             send_kwargs["timeout"] = (
-                WRITE_DEFAULT_TIMEOUT if method in {"POST", "PUT", "DELETE", "PATCH"} else READ_DEFAULT_TIMEOUT
+                WRITE_DEFAULT_TIMEOUT if method in {"POST", "PUT", "DELETE", "PATCH", "QUERY"} else READ_DEFAULT_TIMEOUT
             )
 
         return await self.send(prep, **send_kwargs)
@@ -1636,6 +1636,86 @@ class AsyncSession(Session):
             stream=stream,  # type: ignore[arg-type]
             cert=cert,
             **kwargs,
+        )
+
+    @typing.overload  # type: ignore[override]
+    async def query(
+        self,
+        url: str,
+        data: BodyType | AsyncBodyType | None = ...,
+        json: typing.Any | None = ...,
+        *,
+        params: QueryParameterType | None = ...,
+        headers: HeadersType | None = ...,
+        cookies: CookiesType | None = ...,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = ...,
+        auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = ...,
+        timeout: TimeoutType | None = ...,
+        allow_redirects: bool = ...,
+        proxies: ProxyType | None = ...,
+        hooks: AsyncHookType[PreparedRequest | Response] | None = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[False] | Literal[None] = ...,
+        cert: TLSClientCertType | None = ...,
+    ) -> Response: ...
+
+    @typing.overload  # type: ignore[override]
+    async def query(
+        self,
+        url: str,
+        data: BodyType | AsyncBodyType | None = ...,
+        json: typing.Any | None = ...,
+        *,
+        params: QueryParameterType | None = ...,
+        headers: HeadersType | None = ...,
+        cookies: CookiesType | None = ...,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = ...,
+        auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = ...,
+        timeout: TimeoutType | None = ...,
+        allow_redirects: bool = ...,
+        proxies: ProxyType | None = ...,
+        hooks: AsyncHookType[PreparedRequest | Response] | None = ...,
+        verify: TLSVerifyType | None = ...,
+        stream: Literal[True],
+        cert: TLSClientCertType | None = ...,
+    ) -> AsyncResponse: ...
+
+    async def query(  # type: ignore[override]
+        self,
+        url: str,
+        data: BodyType | AsyncBodyType | None = None,
+        json: typing.Any | None = None,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | AsyncHttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = None,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: AsyncHookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
+        cert: TLSClientCertType | None = None,
+    ) -> Response | AsyncResponse:
+        return await self.request(  # type: ignore[call-overload,misc]
+            "QUERY",
+            url,
+            data=data,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,  # type: ignore[arg-type]
+            cert=cert,
         )
 
     async def gather(self, *responses: Response, max_fetch: int | None = None) -> None:  # type: ignore[override]

--- a/src/niquests/extensions/tls/__init__.py
+++ b/src/niquests/extensions/tls/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import typing
+from dataclasses import dataclass
+
+if typing.TYPE_CHECKING:
+    from ...packages.urllib3.contrib.anytls import ssl
+
+
+@dataclass
+class TLSConfiguration:
+    backend: typing.Literal["utls", "rtls", "ssl"] | None = None
+    min_version: ssl.TLSVersion | None = None
+    max_version: ssl.TLSVersion | None = None
+    ciphers: str | None = None
+
+
+__all__ = ("TLSConfiguration",)

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -690,7 +690,7 @@ class Session:
 
         if send_kwargs["timeout"] is None:
             send_kwargs["timeout"] = (
-                WRITE_DEFAULT_TIMEOUT if method in {"POST", "PUT", "DELETE", "PATCH"} else READ_DEFAULT_TIMEOUT
+                WRITE_DEFAULT_TIMEOUT if method in {"POST", "PUT", "DELETE", "PATCH", "QUERY"} else READ_DEFAULT_TIMEOUT
             )
 
         resp = self.send(prep, **send_kwargs)
@@ -1208,6 +1208,91 @@ class Session:
             stream=stream,
             cert=cert,
             **kwargs,
+        )
+
+    def query(
+        self,
+        url: str,
+        data: BodyType | None = None,
+        json: typing.Any | None = None,
+        *,
+        params: QueryParameterType | None = None,
+        headers: HeadersType | None = None,
+        cookies: CookiesType | None = None,
+        files: MultiPartFilesType | MultiPartFilesAltType | None = None,
+        auth: HttpAuthenticationType | None = None,
+        timeout: TimeoutType | None = None,
+        allow_redirects: bool = True,
+        proxies: ProxyType | None = None,
+        hooks: HookType[PreparedRequest | Response] | None = None,
+        verify: TLSVerifyType | None = None,
+        stream: bool | None = None,
+        cert: TLSClientCertType | None = None,
+    ) -> Response:
+        r"""Sends a QUERY request. Returns :class:`Response` object.
+
+        The QUERY method (:rfc:`10008`) requests that the server process the
+        enclosed content as a query and respond with the result. It is similar
+        to POST in that the query is carried in the request body, but unlike
+        POST it is safe and idempotent, allowing requests to be cached and
+        automatically retried.
+
+        :param url: URL for the new :class:`Request` object.
+        :param params: (optional) Dictionary or bytes to be sent in the query
+            string for the :class:`Request`.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the
+            :class:`Request`.
+        :param headers: (optional) Dictionary of HTTP Headers to send with the
+            :class:`Request`.
+        :param cookies: (optional) Dict or CookieJar object to send with the
+            :class:`Request`.
+        :param files: (optional) Dictionary of ``'filename': file-like-objects``
+            for multipart encoding upload.
+        :param auth: (optional) Auth tuple or callable to enable
+            Basic/Digest/Custom HTTP Auth.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :param allow_redirects: (optional) Set to True by default.
+        :param proxies: (optional) Dictionary mapping protocol or protocol and
+            hostname to the URL of the proxy.
+        :param hooks: (optional) Dictionary mapping hook name to one event or
+            list of events, event must be callable.
+        :param stream: (optional) whether to immediately download the response
+            content. Defaults to ``False``.
+        :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a path passed as a string or os.Pathlike object,
+            in which case it must be a path to a CA bundle to use.
+            Defaults to ``True``. When set to
+            ``False``, requests will accept any TLS certificate presented by
+            the server, and will ignore hostname mismatches and/or expired
+            certificates, which will make your application vulnerable to
+            man-in-the-middle (MitM) attacks. Setting verify to ``False``
+            may be useful during local development or testing.
+            It is also possible to put the certificates (directly) in a string or bytes.
+        :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair, or ('cert', 'key', 'key_password').
+        """
+
+        return self.request(
+            "QUERY",
+            url,
+            data=data,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            verify=verify,
+            stream=stream,
+            cert=cert,
         )
 
     def send(self, request: PreparedRequest, **kwargs: typing.Any) -> Response:

--- a/src/niquests/sessions.py
+++ b/src/niquests/sessions.py
@@ -45,6 +45,7 @@ from .exceptions import (
 from .extensions.revocation import DEFAULT_STRATEGY, RevocationConfiguration
 from .extensions.sgi import WebServerGatewayInterface
 from .extensions.sgi._async import ThreadAsyncServerGatewayInterface
+from .extensions.tls import TLSConfiguration
 from .extensions.unixsocket import UnixAdapter
 
 try:
@@ -245,6 +246,7 @@ class Session:
         "quic_cache_layer",
         "timeout",
         "_revocation_configuration",
+        "_tls_configuration",
     ]
 
     def __init__(
@@ -278,6 +280,7 @@ class Session:
         verify: TLSVerifyType | None = None,
         cert: TLSClientCertType | None = None,
         allow_incoming_cookies: bool = True,
+        tls_configuration: TLSConfiguration | None = None,
     ):
         """
         :param resolver: Specify a DNS resolver that should be used within this Session.
@@ -318,6 +321,8 @@ class Session:
         :param allow_incoming_cookies: Toggle whether cookies sent by the remote peer (via ``Set-Cookie``)
             should be extracted and merged into this Session. Set it to ``False`` to ignore every incoming
             cookie. Outgoing cookies you set yourself are still sent. Defaults to ``True``.
+        :param tls_configuration: Fine-grained TLS configuration (desired backend, minimum/maximum TLS
+            version, and cipher list) propagated to every TLS-capable adapter mounted on this Session.
         """
         if [disable_ipv4, disable_ipv6].count(True) == 2:
             raise RuntimeError("Cannot disable both IPv4 and IPv6")
@@ -445,6 +450,9 @@ class Session:
         #: How we should handle the revocation check for TLS newly acquired connection.
         self._revocation_configuration: RevocationConfiguration | None = revocation_configuration
 
+        #: Fine-grained TLS configuration (backend, min/max version, ciphers) propagated to adapters.
+        self._tls_configuration: TLSConfiguration | None = tls_configuration
+
         # Default connection adapters.
         self.adapters: OrderedDict[str, BaseAdapter] = OrderedDict()
         if PyodideAdapter is None:
@@ -467,6 +475,7 @@ class Session:
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
             self.mount(
@@ -487,6 +496,7 @@ class Session:
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
             self.mount(
@@ -507,6 +517,7 @@ class Session:
                     keepalive_idle_window=keepalive_idle_window,
                     revocation_configuration=revocation_configuration,
                     allow_incoming_cookies=allow_incoming_cookies,
+                    tls_configuration=tls_configuration,
                 ),
             )
         else:
@@ -1464,6 +1475,7 @@ class Session:
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
                     allow_incoming_cookies=self.allow_incoming_cookies,
+                    tls_configuration=self._tls_configuration,
                 ),
             )
             self.mount(
@@ -1484,6 +1496,7 @@ class Session:
                     keepalive_idle_window=self._keepalive_idle_window,
                     revocation_configuration=self._revocation_configuration,
                     allow_incoming_cookies=self.allow_incoming_cookies,
+                    tls_configuration=self._tls_configuration,
                 ),
             )
             self.mount(
@@ -1760,6 +1773,7 @@ class Session:
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
                 allow_incoming_cookies=self.allow_incoming_cookies,
+                tls_configuration=self._tls_configuration,
             ),
         )
         self.mount(
@@ -1780,6 +1794,7 @@ class Session:
                 keepalive_idle_window=self._keepalive_idle_window,
                 revocation_configuration=self._revocation_configuration,
                 allow_incoming_cookies=self.allow_incoming_cookies,
+                tls_configuration=self._tls_configuration,
             ),
         )
         self.mount(

--- a/src/niquests/utils.py
+++ b/src/niquests/utils.py
@@ -20,6 +20,7 @@ import struct
 import sys
 import tempfile
 import typing
+import warnings
 from collections import OrderedDict
 from functools import lru_cache
 from http.cookiejar import CookieJar
@@ -44,6 +45,7 @@ from .__version__ import __version__
 from ._compat import iscoroutinefunction
 from .exceptions import InvalidURL, MissingSchema, UnrewindableBodyError
 from .extensions.revocation import RevocationConfiguration, RevocationStrategy
+from .extensions.tls import TLSConfiguration
 from .packages.urllib3 import ConnectionInfo
 from .packages.urllib3.contrib.resolver import (
     BaseResolver,
@@ -1518,3 +1520,52 @@ def merge_base_url(base_url: str | None, url: str | None) -> str | None:
         return base_url + url
 
     return url
+
+
+@lru_cache()
+def _supports_ssl_backend() -> bool:
+    """The ``ssl_backend`` keyword argument is only available since urllib3-future 2.22.900.
+
+    We deliberately avoid raising the lower bound for this optional feature, so we have to
+    detect at runtime whether the installed urllib3-future is recent enough.
+    """
+    from .packages.urllib3 import __version__ as urllib3_version
+
+    try:
+        major, minor, patch = (int(part) for part in urllib3_version.split(".")[:3])
+    except (ValueError, TypeError):  # Defensive: unexpected version string
+        return False
+
+    return (major, minor, patch) >= (2, 22, 900)
+
+
+def tls_configuration_to_pool_kwargs(configuration: TLSConfiguration | None) -> dict[str, typing.Any]:
+    """Translate a :class:`TLSConfiguration` into PoolManager/ProxyManager keyword arguments.
+
+    The ``ssl_backend`` keyword argument is guarded: if the installed urllib3-future is older
+    than 2.22.900, we emit a warning and drop the ``backend`` setting instead of passing an
+    unsupported keyword argument down to the connection pool.
+    """
+    if configuration is None:
+        return {}
+
+    pool_kwargs: dict[str, typing.Any] = {}
+
+    if configuration.min_version is not None:
+        pool_kwargs["ssl_minimum_version"] = configuration.min_version
+    if configuration.max_version is not None:
+        pool_kwargs["ssl_maximum_version"] = configuration.max_version
+    if configuration.ciphers is not None:
+        pool_kwargs["ciphers"] = configuration.ciphers
+    if configuration.backend is not None:
+        if _supports_ssl_backend():
+            pool_kwargs["ssl_backend"] = configuration.backend
+        else:
+            warnings.warn(
+                "TLSConfiguration.backend (ssl_backend) requires urllib3-future 2.22.900 or later. "
+                "The installed version is too old, so the requested TLS backend is ignored. "
+                "Upgrade urllib3-future to enable this feature.",
+                stacklevel=2,
+            )
+
+    return pool_kwargs


### PR DESCRIPTION
3.20.0 (2026-06-26)
-------------------

**Added**
- Method/Verb `QUERY` as one of the promoted HTTP verb and available through top level function shortcuts and `Session`/`AsyncSession` methods.
  This is following the RFC 10008. A long awaited standardized verb. Any other non-standard verb is still supported through manual `request(...)` calls.
- A `TLSConfiguration` object to let you take a deeper control over the TLS configuration.
  This object will allow you to change min, max TLS version, as the cipher list and finally the desired TLS backend.

**Fixed**
- Typing overload for `AsyncResponse` iter_lines method. (#413)